### PR TITLE
Remove irrelevant vulnerabilities from output #143

### DIFF
--- a/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/engine/IfdsResult.kt
+++ b/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/engine/IfdsResult.kt
@@ -80,9 +80,7 @@ class IfdsResult(
                     }
                     is PredecessorKind.Unknown -> {
                         addEdge(pred.predEdge.v, lastVertex)
-                        if (pred.predEdge.u == pred.predEdge.v && !stopAtMethodStart) {
-                            sources.add(pred.predEdge.v)
-                        } else { // Turning point
+                        if (pred.predEdge.u != pred.predEdge.v) {
                             // TODO: ideally, we should analyze the place from which the edge was given to ifds,
                             //  for now we just go to method start
                             dfs(IfdsEdge(pred.predEdge.u, pred.predEdge.u), pred.predEdge.v, stopAtMethodStart)

--- a/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/graph/ApplicationGraphFactory.kt
+++ b/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/graph/ApplicationGraphFactory.kt
@@ -49,4 +49,5 @@ val defaultBannedPackagePrefixes: List<String> = listOf(
     "java.",
     "jdk.internal.",
     "sun.",
+    "javax.",
 )

--- a/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/library/analyzers/NpeAnalyzer.kt
+++ b/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/library/analyzers/NpeAnalyzer.kt
@@ -222,9 +222,9 @@ private class NpeForwardFunctions(
 
         val thisInstance = method.thisInstance
 
-        // Possibly null fields
+        // Possibly null public non-final fields
         result += method.enclosingClass.fields
-            .filter { it.isNullable != false && !it.isStatic }
+            .filter { it.isNullable != false && !it.isStatic && it.isPublic && !it.isFinal }
             .map {
                 NpeTaintNode(
                     AccessPath.fromOther(AccessPath.fromLocal(thisInstance), listOf(FieldAccessor(it)))

--- a/jacodb-cli/src/main/kotlin/org/jacodb/cli/main.kt
+++ b/jacodb-cli/src/main/kotlin/org/jacodb/cli/main.kt
@@ -39,6 +39,7 @@ import org.jacodb.api.JcClassOrInterface
 import org.jacodb.api.JcClassProcessingTask
 import org.jacodb.api.JcMethod
 import org.jacodb.api.analysis.JcApplicationGraph
+import org.jacodb.api.ext.methods
 import org.jacodb.impl.features.InMemoryHierarchy
 import org.jacodb.impl.features.Usages
 import org.jacodb.impl.jacodb
@@ -144,8 +145,7 @@ fun main(args: Array<String>) {
             }
         }
     }).get()
-    val startJcMethods = startJcClasses.flatMap { it.declaredMethods }
-
+    val startJcMethods = startJcClasses.flatMap { it.methods }.filter { it.isPublic }
 
     val graph = runBlocking {
         cp.newApplicationGraphForAnalysis()


### PR DESCRIPTION
- NPE is no more reported if it needs for final/private field to be externally set to null
- Start analysis in cli only from public methods