### PR TITLE
Publish test results in a separate job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,17 +3,10 @@ name: Build and run tests
 on:
   push:
   pull_request:
-    branches:
-      - develop
+    types: [opened, reopened]
 
 jobs:
   build:
-    # Skip duplicate build when pushing to already existing PR
-    # Note: we decided NOT to skip duplicate builds,
-    #       since we upload test results via 'EnricoMi/publish-unit-test-result-action',
-    #       which requires 'pull_request' trigger for the bot to be able to add a comment to PR.
-    # if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     name: Build on JDK ${{ matrix.jdk }}
 
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - develop
 
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
-
 jobs:
   build:
     # Skip duplicate build when pushing to already existing PR
@@ -48,29 +43,46 @@ jobs:
       - name: Build and run tests
         run: ./gradlew build --stacktrace --scan
 
-      - name: Publish test results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: always()
-        with:
-          files: "**/build/test-results/**/*.xml"
-          check_name: "Test results on JDK ${{ matrix.jdk }}"
-
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         if: matrix.jdk == env.main_jdk
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      # - name: Upload test results
-      #   uses: actions/upload-artifact@v3
-      #   with:
-      #     name: test-results
-      #     path: build/test-results/
-
-      - name: Upload Gradle reports
-        if: (!cancelled()) && matrix.jdk == env.main_jdk
+      - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: gradle-reports
-          path: '**/build/reports/'
+          name: test-results-jdk${{ matrix.jdk }}
+          path: ./**/build/test-results/
+
+      - name: Upload Gradle reports
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: gradle-reports-jdk${{ matrix.jdk }}
+          path: ./**/build/reports/
           retention-days: 1
+
+  publish-test-results:
+    name: Publish test results
+
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: "artifacts/**/*.xml"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,4 +78,4 @@ jobs:
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          files: "artifacts/**/test-results/*.xml"
+          files: "artifacts/**/test-results/**/*.xml"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -78,4 +78,4 @@ jobs:
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          files: "artifacts/**/*.xml"
+          files: "artifacts/**/test-results/*.xml"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,8 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [8, 11, 19]
-    env:
-      main_jdk: 8
 
     steps:
       - uses: actions/checkout@v3
@@ -37,23 +35,23 @@ jobs:
         run: ./gradlew build --stacktrace --scan
 
       - name: Upload coverage reports to Codecov
+        if: matrix.jdk == '8'
         uses: codecov/codecov-action@v3
-        if: matrix.jdk == env.main_jdk
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results
-        if: always()
+        if: (!cancelled())
         uses: actions/upload-artifact@v3
         with:
           name: test-results-jdk${{ matrix.jdk }}
           path: ./**/build/test-results/
 
-      - name: Upload Gradle reports
-        if: always()
+      - name: Upload coverage reports
+        if: (!cancelled())
         uses: actions/upload-artifact@v3
         with:
-          name: gradle-reports-jdk${{ matrix.jdk }}
+          name: coverage-reports-jdk${{ matrix.jdk }}
           path: ./**/build/reports/
           retention-days: 1
 
@@ -62,7 +60,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: build
-    if: always()
+    if: (!cancelled())
 
     permissions:
       contents: read


### PR DESCRIPTION
This PR changes CI workflow such that it uploads tests results and jacoco reports as artifacts from all matrix builds, and then publishes them (test results as a comment to PR, and jacoco results to codecov.io) in a separate job