### PR TITLE
jacodb-approximations: fix fields and methods equality

### DIFF
--- a/jacodb-approximations/src/main/kotlin/org/jacodb/approximation/VirtualInstances.kt
+++ b/jacodb-approximations/src/main/kotlin/org/jacodb/approximation/VirtualInstances.kt
@@ -59,6 +59,22 @@ class JcEnrichedVirtualMethod(
         it.flowGraph(this)
     }!!.flowGraph
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as JcEnrichedVirtualMethod
+
+        if (name != other.name) return false
+        if (enclosingClass != other.enclosingClass) return false
+        if (description != other.description) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int =
+        name.hashCode() * 31 + enclosingClass.hashCode()
+
     override val signature: String?
         get() = null
 }
@@ -79,4 +95,18 @@ class JcEnrichedVirtualField(
 ) : JcVirtualFieldImpl(name, access, type) {
     override val signature: String?
         get() = null
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as JcEnrichedVirtualField
+
+        if (name != other.name) return false
+        if (enclosingClass != other.enclosingClass) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = name.hashCode() * 31 + enclosingClass.hashCode()
 }

--- a/jacodb-approximations/src/test/kotlin/org/jacodb/approximations/ApproximationsTest.kt
+++ b/jacodb-approximations/src/test/kotlin/org/jacodb/approximations/ApproximationsTest.kt
@@ -94,6 +94,8 @@ class ApproximationsTest : BaseTest() {
         assertTrue("sameApproximationTarget" in originalFieldsNames)
         assertTrue("anotherApproximationTarget" in originalFieldsNames)
         assertTrue("fieldWithoutApproximation" in originalFieldsNames)
+
+        assertEquals(fields, classec.declaredFields)
     }
 
     @Test
@@ -119,6 +121,8 @@ class ApproximationsTest : BaseTest() {
 
         assertTrue(originalMethods.size == 1)
         assertTrue("methodWithoutApproximation" in originalMethodsNames)
+
+        assertEquals(methods, classec.declaredMethods)
     }
 
     @Test


### PR DESCRIPTION
Currently `class.declaredFields != class.declaredFields` for approximated classes.