### PR TITLE
Fixed runtime persistence

### DIFF
--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/SQLitePersistenceImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/SQLitePersistenceImpl.kt
@@ -73,7 +73,7 @@ class SQLitePersistenceImpl(
         get() {
             try {
                 val hasBytecodeLocations = jooq.meta().tables
-                    .any { it.name.equals(BYTECODELOCATIONS.bytecodelocations().name, true) }
+                    .any { it.name.equals(BYTECODELOCATIONS.name, true) }
                 if (hasBytecodeLocations) {
                     val count = jooq.fetchCount(
                         BYTECODELOCATIONS,


### PR DESCRIPTION
Without this fix JacoDB looks for alias instead of `BytecodeLocations` table. In result, it rebuilds the runtime every time from scratch even if it is already initialized.