### PR TITLE
Fix lambda expressions

### DIFF
--- a/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcInst.kt
+++ b/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcInst.kt
@@ -670,11 +670,18 @@ data class JcPhiExpr(
  * object, but stores a reference to the actual method
  */
 data class JcLambdaExpr(
-    private val methodRef: TypedMethodRef,
-    override val args: List<JcValue>,
+    private val bsmRef: TypedMethodRef,
+    val actualMethod: TypedMethodRef,
+    val interfaceMethodType: BsmMethodTypeArg,
+    val dynamicMethodType: BsmMethodTypeArg,
+    val callSiteMethodName: String,
+    val callSiteArgTypes: List<JcType>,
+    val callSiteReturnType: JcType,
+    val callSiteArgs: List<JcValue>
 ) : JcCallExpr {
 
-    override val method: JcTypedMethod get() = methodRef.method
+    override val method get() = bsmRef.method
+    override val args get() = callSiteArgs
 
     override fun <T> accept(visitor: JcExprVisitor<T>): T {
         return visitor.visitJcLambdaExpr(this)

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/types.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/types.kt
@@ -31,6 +31,7 @@ internal const val METHOD_HANDLE_CLASS = "Ljava.lang.invoke.MethodHandle;"
 internal const val METHOD_HANDLES_CLASS = "Ljava.lang.invoke.MethodHandles;"
 internal const val METHOD_HANDLES_LOOKUP_CLASS = "Ljava.lang.invoke.MethodHandles\$Lookup;"
 internal const val METHOD_TYPE_CLASS = "Ljava.lang.invoke.MethodType;"
+internal const val LAMBDA_METAFACTORY_CLASS = "Ljava.lang.invoke.LambdaMetafactory;"
 internal val TOP = "TOP".typeName()
 internal val UNINIT_THIS = "UNINIT_THIS".typeName()
 

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/InvokeDynamicTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/InvokeDynamicTest.kt
@@ -1,0 +1,54 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jacodb.testing.cfg
+
+import org.jacodb.api.ext.findClass
+import org.jacodb.testing.WithDB
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class InvokeDynamicTest : BaseInstructionsTest() {
+
+    companion object : WithDB()
+
+    @Test
+    fun `test unary function`() = runStaticMethod<InvokeDynamicExamples>("testUnaryFunction")
+
+    @Test
+    fun `test method ref unary function`() = runStaticMethod<InvokeDynamicExamples>("testMethodRefUnaryFunction")
+
+    @Test
+    fun `test currying function`() = runStaticMethod<InvokeDynamicExamples>("testCurryingFunction")
+
+    @Test
+    fun `test sam function`() = runStaticMethod<InvokeDynamicExamples>("testSamFunction")
+
+    @Test
+    fun `test sam with default function`() = runStaticMethod<InvokeDynamicExamples>("testSamWithDefaultFunction")
+
+    @Test
+    fun `test complex invoke dynamic`() = runStaticMethod<InvokeDynamicExamples>("testComplexInvokeDynamic")
+
+    private inline fun <reified T> runStaticMethod(name: String) {
+        val clazz = cp.findClass<T>()
+
+        val javaClazz = testAndLoadClass(clazz)
+        val method = javaClazz.methods.single { it.name == name }
+        val res = method.invoke(null)
+        assertEquals("OK", res)
+    }
+}

--- a/jacodb-core/src/testFixtures/java/org/jacodb/testing/cfg/InvokeDynamicExamples.java
+++ b/jacodb-core/src/testFixtures/java/org/jacodb/testing/cfg/InvokeDynamicExamples.java
@@ -1,0 +1,98 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jacodb.testing.cfg;
+
+import java.util.function.Function;
+
+public class InvokeDynamicExamples {
+
+    private static int runUnaryFunction(String data, Function<String, Integer> f) {
+        if (data.isEmpty()) {
+            return -1;
+        }
+
+        int result = f.apply(data);
+        return result + 17;
+    }
+
+    private static int runSamFunction(String data, SamBase f) {
+        if (data.isEmpty()) {
+            return -1;
+        }
+        int result = f.samFunction(data);
+        return result + 17;
+    }
+
+    private static int runDefaultFunction(String data, SamBase f) {
+        if (data.isEmpty()) {
+            return -1;
+        }
+        int result = f.defaultFunction(data);
+        return result + 17;
+    }
+
+    private static String runComplexStringConcat(String str, int v) {
+        return str + v + 'x' + str + 17 + str;
+    }
+
+    public interface SamBase {
+        int samFunction(String data);
+
+        default int defaultFunction(String data) {
+            if (data.isEmpty()) {
+                return -2;
+            }
+            return samFunction(data) + 31;
+        }
+    }
+
+    private static int add(int a, int b) {
+        return a + b;
+    }
+
+    public static String testUnaryFunction() {
+        int res = runUnaryFunction("abc", s -> s.length());
+        return res == ("abc".length() + 17) ? "OK" : "BAD";
+    }
+
+    public static String testMethodRefUnaryFunction() {
+        int res = runUnaryFunction("abc", String::length);
+        return res == ("abc".length() + 17) ? "OK" : "BAD";
+    }
+
+    public static String testCurryingFunction() {
+        Function<Integer, Integer> add42 = x -> add(x, 42);
+        int res = runUnaryFunction("abc", s -> add42.apply(s.length()));
+        return res == ("abc".length() + 17 + 42) ? "OK" : "BAD";
+    }
+
+    public static String testSamFunction() {
+        int res = runSamFunction("abc", s -> s.length());
+        return res == ("abc".length() + 17) ? "OK" : "BAD";
+    }
+
+    public static String testSamWithDefaultFunction() {
+        int res = runDefaultFunction("abc", s -> s.length());
+        return res == ("abc".length() + 17 + 31) ? "OK" : "BAD";
+    }
+
+    public static String testComplexInvokeDynamic() {
+        String expected = "abc42xabc17abc";
+        String actual = runComplexStringConcat("abc", 42);
+        return expected.equals(actual) ? "OK" : "BAD";
+    }
+}


### PR DESCRIPTION
`InstListBuilder` currenlty uses too wide pattern to recognize lambda and may incorreclty rewrite dynamic invoke.
Also, `JcLambdaExpr` is currently missing important information about the method name and signature.