### PR TITLE
Update pre-commit

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,5 +1,11 @@
 #!/bin/sh
 
-echo "***** Check license before commit ******"
+echo "***** Check license headers before commit *****"
 
-./gradlew checkLicense
+if [ "$(expr substr $(uname -s) 1 5)" == "MINGW" ]; then
+   ./gradlew.bat checkLicense
+elif [ "$(expr substr $(uname -s) 1 4)" == "MSYS" ]; then
+   ./gradlew.bat checkLicense
+else
+   ./gradlew checkLicense
+fi

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ rootProject.name = "jacodb"
 
 plugins {
     `gradle-enterprise`
-    id("org.danilopianini.gradle-pre-commit-git-hooks") version "1.0.25"
+    id("org.danilopianini.gradle-pre-commit-git-hooks") version "1.1.11"
 }
 
 gradleEnterprise {
@@ -14,10 +14,9 @@ gradleEnterprise {
 
 gitHooks {
     preCommit {
-        // Content can be added at the bottom of the script
-        from(file("pre-commit").toURI().toURL())
+        from(file("pre-commit"))
     }
-    createHooks() // actual hooks creation
+    createHooks(true)
 }
 
 include("jacodb-api")


### PR DESCRIPTION
Modify pre-commit hook to use `gradlew.bat` in Windows-like (MINGW/MSYS) environment. [See relevant repo](https://github.com/benweizhu/gradle-git-hooks-example/blob/master/git-hooks/pre-commit). I have stumbled upon this because GitKraken on my Windows machine uses cygwin environment, which struggles running `gradlew`.

Additionally, bump [gradle-pre-commit-hooks](https://github.com/DanySK/gradle-pre-commit-git-hooks) plugin to the latest version 1.1.11, allowing (since 1.1.0) for configuring hooks from `file`s (via `from(file("<path/to/hook>"))`).