### PR TITLE
Bug with invocations of static interfaces methods fixed

### DIFF
--- a/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
+++ b/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
@@ -762,6 +762,7 @@ data class JcRawStaticCallExpr(
     override val argumentTypes: List<TypeName>,
     override val returnType: TypeName,
     override val args: List<JcRawValue>,
+    val isInterface: Boolean = false,
 ) : JcRawCallExpr {
     override fun toString(): String =
         "$declaringClass.$methodName${args.joinToString(prefix = "(", postfix = ")", separator = ", ")}"

--- a/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
+++ b/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
@@ -762,7 +762,7 @@ data class JcRawStaticCallExpr(
     override val argumentTypes: List<TypeName>,
     override val returnType: TypeName,
     override val args: List<JcRawValue>,
-    val isInterface: Boolean = false,
+    val isInterfaceMethodCall: Boolean = false,
 ) : JcRawCallExpr {
     override fun toString(): String =
         "$declaringClass.$methodName${args.joinToString(prefix = "(", postfix = ")", separator = ", ")}"

--- a/jacodb-approximations/src/main/kotlin/org/jacodb/approximation/InstSubstitutorForApproximations.kt
+++ b/jacodb-approximations/src/main/kotlin/org/jacodb/approximation/InstSubstitutorForApproximations.kt
@@ -366,7 +366,7 @@ object InstSubstitutorForApproximations : JcRawInstVisitor<JcRawInst>, JcRawExpr
                 argumentTypes.map { it.eliminateApproximation() },
                 returnType.eliminateApproximation(),
                 newArgs,
-                isInterface
+                isInterfaceMethodCall
             )
         }
     }

--- a/jacodb-approximations/src/main/kotlin/org/jacodb/approximation/InstSubstitutorForApproximations.kt
+++ b/jacodb-approximations/src/main/kotlin/org/jacodb/approximation/InstSubstitutorForApproximations.kt
@@ -365,7 +365,8 @@ object InstSubstitutorForApproximations : JcRawInstVisitor<JcRawInst>, JcRawExpr
                 methodName,
                 argumentTypes.map { it.eliminateApproximation() },
                 returnType.eliminateApproximation(),
-                newArgs
+                newArgs,
+                isInterface
             )
         }
     }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/MethodNodeBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/MethodNodeBuilder.kt
@@ -266,7 +266,6 @@ class MethodNodeBuilder(
         val trueTarget = label(inst.trueBranch)
         val falseTarget = label(inst.falseBranch)
         val cond = inst.condition
-        var shouldReverse = false
         val (zeroValue, zeroCmpOpcode, defaultOpcode) = when (cond) {
             is JcRawEqExpr -> when {
                 cond.lhv.typeName == PredefinedPrimitives.Null.typeName() -> Triple(
@@ -675,7 +674,8 @@ class MethodNodeBuilder(
                 Opcodes.INVOKESTATIC,
                 expr.declaringClass.jvmClassName,
                 expr.methodName,
-                expr.methodDesc
+                expr.methodDesc,
+                expr.isInterface
             )
         )
         updateStackInfo(-expr.args.size)

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/MethodNodeBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/MethodNodeBuilder.kt
@@ -675,7 +675,7 @@ class MethodNodeBuilder(
                 expr.declaringClass.jvmClassName,
                 expr.methodName,
                 expr.methodDesc,
-                expr.isInterface
+                expr.isInterfaceMethodCall
             )
         )
         updateStackInfo(-expr.args.size)

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/RawInstListBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/RawInstListBuilder.kt
@@ -25,11 +25,6 @@ import org.jacodb.impl.cfg.util.*
 import org.jacodb.impl.types.TypeNameImpl
 import org.objectweb.asm.*
 import org.objectweb.asm.tree.*
-import org.objectweb.asm.util.Printer
-import org.objectweb.asm.util.Textifier
-import org.objectweb.asm.util.TraceMethodVisitor
-import java.io.PrintWriter
-import java.io.StringWriter
 import java.util.*
 
 
@@ -1400,7 +1395,8 @@ class RawInstListBuilder(
                                 lookupAssignment,
                                 JcRawStringConstant(cst.name, STRING_CLASS.typeName()),
                                 JcRawClassConstant(cst.descriptor.typeName(), CLASS_CLASS.typeName())
-                            ) + exprs
+                            ) + exprs,
+                            methodHande.isInterface
                         )
                     }
                 }
@@ -1438,7 +1434,8 @@ class RawInstListBuilder(
                 methodName,
                 argTypes,
                 returnType,
-                args
+                args,
+                insnNode.itf
             )
 
             else -> {
@@ -1555,7 +1552,7 @@ class RawInstListBuilder(
                 variable,
                 pop(),
                 insnNode
-            )?.let { addInstruction(insnNode, it) }
+            ).let { addInstruction(insnNode, it) }
 
             in Opcodes.ILOAD..Opcodes.ALOAD -> {
                 push(local(variable))

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/ExprMapper.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/ExprMapper.kt
@@ -364,7 +364,7 @@ class ExprMapper(val mapping: Map<JcRawExpr, JcRawExpr>) : JcRawInstVisitor<JcRa
         when (expr.args) {
             newArgs -> expr
             else -> JcRawStaticCallExpr(
-                expr.declaringClass, expr.methodName, expr.argumentTypes, expr.returnType, newArgs
+                expr.declaringClass, expr.methodName, expr.argumentTypes, expr.returnType, newArgs, expr.isInterface
             )
         }
     }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/ExprMapper.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/ExprMapper.kt
@@ -364,7 +364,7 @@ class ExprMapper(val mapping: Map<JcRawExpr, JcRawExpr>) : JcRawInstVisitor<JcRa
         when (expr.args) {
             newArgs -> expr
             else -> JcRawStaticCallExpr(
-                expr.declaringClass, expr.methodName, expr.argumentTypes, expr.returnType, newArgs, expr.isInterface
+                expr.declaringClass, expr.methodName, expr.argumentTypes, expr.returnType, newArgs, expr.isInterfaceMethodCall
             )
         }
     }

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/InstructionsTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/InstructionsTest.kt
@@ -265,6 +265,15 @@ class InstructionsTest : BaseInstructionsTest() {
         assertEquals("defaultMethod", callDefaultMethod.method.method.name)
     }
 
+    @Test
+    fun `static interface method call`() {
+        val clazz = cp.findClass<StaticInterfaceMethodCall>()
+
+        val javaClazz = testAndLoadClass(clazz)
+        val method = javaClazz.methods.first { it.name == "callStaticInterfaceMethod" }
+        val res = method.invoke(null)
+        assertNull(res)
+    }
 
     @Test
     fun `condition in for should work`() {

--- a/jacodb-core/src/testFixtures/java/org/jacodb/testing/cfg/StaticInterfaceMethodCall.java
+++ b/jacodb-core/src/testFixtures/java/org/jacodb/testing/cfg/StaticInterfaceMethodCall.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jacodb.testing.cfg;
+
+import java.util.function.Function;
+
+public class StaticInterfaceMethodCall {
+    public static void callStaticInterfaceMethod() {
+        Function.identity();
+    }
+}


### PR DESCRIPTION
IMPORTANT:
`JcRawInst` API changed! (Added boolean `isInterface` property to JcRawStaticCallExpr with default value of `false`)
Please make sure it doesn't break anything