### PR TITLE
Keep local variable names feature

### DIFF
--- a/jacodb-analysis/src/test/kotlin/org/jacodb/analysis/impl/BaseAnalysisTest.kt
+++ b/jacodb-analysis/src/test/kotlin/org/jacodb/analysis/impl/BaseAnalysisTest.kt
@@ -88,7 +88,9 @@ abstract class BaseAnalysisTest : BaseTest() {
         // TODO: think about better assertions here
         assertEquals(expectedLocations.size, sinks.size)
         expectedLocations.forEach { expected ->
-            assertTrue(sinks.any { it.contains(expected) })
+            assertTrue(sinks.any { it.contains(expected) }) {
+                "$expected unmatched in:\n${sinks.joinToString("\n")}"
+            }
         }
     }
 

--- a/jacodb-analysis/src/test/kotlin/org/jacodb/analysis/impl/NpeAnalysisTest.kt
+++ b/jacodb-analysis/src/test/kotlin/org/jacodb/analysis/impl/NpeAnalysisTest.kt
@@ -60,7 +60,7 @@ class NpeAnalysisTest : BaseAnalysisTest() {
 
     @Test
     fun `analyze simple NPE`() {
-        testOneMethod<NpeExamples>("npeOnLength", listOf("%3 = %0.length()"))
+        testOneMethod<NpeExamples>("npeOnLength", listOf("%3 = x.length()"))
     }
 
     @Test
@@ -72,7 +72,7 @@ class NpeAnalysisTest : BaseAnalysisTest() {
     fun `analyze NPE after fun with two exits`() {
         testOneMethod<NpeExamples>(
             "npeAfterTwoExits",
-            listOf("%4 = %0.length()", "%5 = %1.length()")
+            listOf("%4 = x.length()", "%5 = y.length()")
         )
     }
 
@@ -85,7 +85,7 @@ class NpeAnalysisTest : BaseAnalysisTest() {
     fun `consecutive NPEs handled properly`() {
         testOneMethod<NpeExamples>(
             "consecutiveNPEs",
-            listOf("%2 = arg$0.length()", "%4 = arg$0.length()")
+            listOf("a = x.length()", "c = x.length()")
         )
     }
 
@@ -93,7 +93,7 @@ class NpeAnalysisTest : BaseAnalysisTest() {
     fun `npe on virtual call when possible`() {
         testOneMethod<NpeExamples>(
             "possibleNPEOnVirtualCall",
-            listOf("%0 = arg\$0.length()")
+            listOf("%0 = x.length()")
         )
     }
 
@@ -107,7 +107,7 @@ class NpeAnalysisTest : BaseAnalysisTest() {
 
     @Test
     fun `basic test for NPE on fields`() {
-        testOneMethod<NpeExamples>("simpleNPEOnField", listOf("%8 = %6.length()"))
+        testOneMethod<NpeExamples>("simpleNPEOnField", listOf("len2 = second.length()"))
     }
 
     @Disabled("Flowdroid architecture not supported for async ifds yet")
@@ -152,7 +152,7 @@ class NpeAnalysisTest : BaseAnalysisTest() {
 
     @Test
     fun `NPE on uninitialized array element dereferencing`() {
-        testOneMethod<NpeExamples>("simpleArrayNPE", listOf("%5 = %4.length()"))
+        testOneMethod<NpeExamples>("simpleArrayNPE", listOf("b = %4.length()"))
     }
 
     @Test
@@ -174,7 +174,7 @@ class NpeAnalysisTest : BaseAnalysisTest() {
 
     @Test
     fun `dereferencing field of null object`() {
-        testOneMethod<NpeExamples>("npeOnFieldDeref", listOf("%1 = %0.field"))
+        testOneMethod<NpeExamples>("npeOnFieldDeref", listOf("s = a.field"))
     }
 
     @Test

--- a/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcInst.kt
+++ b/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcInst.kt
@@ -811,8 +811,10 @@ interface JcLocal : JcSimpleValue {
     val name: String
 }
 
+/**
+ * @param name isn't considered in `equals` and `hashcode`
+ */
 data class JcArgument(val index: Int, override val name: String, override val type: JcType) : JcLocal {
-
     companion object {
         @JvmStatic
         fun of(index: Int, name: String?, type: JcType): JcArgument {
@@ -825,13 +827,52 @@ data class JcArgument(val index: Int, override val name: String, override val ty
     override fun <T> accept(visitor: JcExprVisitor<T>): T {
         return visitor.visitJcArgument(this)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as JcArgument
+
+        if (index != other.index) return false
+        if (type != other.type) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = index
+        result = 31 * result + type.hashCode()
+        return result
+    }
 }
 
-data class JcLocalVar(override val name: String, override val type: JcType) : JcLocal {
+/**
+ * @param name isn't considered in `equals` and `hashcode`
+ */
+data class JcLocalVar(val index: Int, override val name: String, override val type: JcType) : JcLocal {
     override fun toString(): String = name
 
     override fun <T> accept(visitor: JcExprVisitor<T>): T {
         return visitor.visitJcLocalVar(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as JcLocalVar
+
+        if (index != other.index) return false
+        if (type != other.type) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = index
+        result = 31 * result + type.hashCode()
+        return result
     }
 }
 

--- a/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
+++ b/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
@@ -845,6 +845,9 @@ data class JcRawArgument(val index: Int, override val name: String, override val
     }
 }
 
+/**
+ * @param name isn't considered in `equals` and `hashcode`
+ */
 data class JcRawLocalVar(val index: Int, override val name: String, override val typeName: TypeName) : JcRawLocal {
     override fun toString(): String = name
 

--- a/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
+++ b/jacodb-api/src/main/kotlin/org/jacodb/api/cfg/JcRawInst.kt
@@ -808,6 +808,9 @@ data class JcRawThis(override val typeName: TypeName) : JcRawSimpleValue {
     }
 }
 
+/**
+ * @param name isn't considered in `equals` and `hashcode`
+ */
 data class JcRawArgument(val index: Int, override val name: String, override val typeName: TypeName) : JcRawLocal {
     companion object {
         @JvmStatic
@@ -822,13 +825,49 @@ data class JcRawArgument(val index: Int, override val name: String, override val
     override fun <T> accept(visitor: JcRawExprVisitor<T>): T {
         return visitor.visitJcRawArgument(this)
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as JcRawArgument
+
+        if (index != other.index) return false
+        if (typeName != other.typeName) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = index
+        result = 31 * result + typeName.hashCode()
+        return result
+    }
 }
 
-data class JcRawLocalVar(override val name: String, override val typeName: TypeName) : JcRawLocal {
+data class JcRawLocalVar(val index: Int, override val name: String, override val typeName: TypeName) : JcRawLocal {
     override fun toString(): String = name
 
     override fun <T> accept(visitor: JcRawExprVisitor<T>): T {
         return visitor.visitJcRawLocalVar(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as JcRawLocalVar
+
+        if (index != other.index) return false
+        if (typeName != other.typeName) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = index
+        result = 31 * result + typeName.hashCode()
+        return result
     }
 }
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/JcDatabaseImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/JcDatabaseImpl.kt
@@ -69,9 +69,9 @@ class JcDatabaseImpl(
 
     private fun List<JcClasspathFeature>?.appendBuiltInFeatures(): List<JcClasspathFeature> {
         if (this != null && any { it is ClasspathCache }) {
-            return this + listOf(KotlinMetadata, MethodInstructionsFeature)
+            return this + listOf(KotlinMetadata, MethodInstructionsFeature(settings.keepLocalVariableNames))
         }
-        return listOf(ClasspathCache(settings.cacheSettings), KotlinMetadata, MethodInstructionsFeature) + orEmpty()
+        return listOf(ClasspathCache(settings.cacheSettings), KotlinMetadata, MethodInstructionsFeature(settings.keepLocalVariableNames)) + orEmpty()
     }
 
     override suspend fun classpath(dirOrJars: List<File>, features: List<JcClasspathFeature>?): JcClasspath {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/JcSettings.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/JcSettings.kt
@@ -45,6 +45,9 @@ class JcSettings {
 
     var persistentClearOnStart: Boolean? = null
 
+    var keepLocalVariableNames: Boolean = false
+        private set
+
     /** jar files which should be loaded right after database is created */
     var predefinedDirOrJars: List<File> = persistentListOf()
         private set
@@ -99,6 +102,10 @@ class JcSettings {
 
     fun loadByteCode(files: List<File>) = apply {
         predefinedDirOrJars = (predefinedDirOrJars + files).toPersistentList()
+    }
+
+    fun keepLocalVariableNames() {
+        keepLocalVariableNames = true
     }
 
     /**

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/bytecode/JcMethodImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/bytecode/JcMethodImpl.kt
@@ -70,7 +70,7 @@ class JcMethodImpl(
     internal fun parameterTypeAnnotationInfos(parameterIndex: Int): List<AnnotationInfo> =
         methodInfo.annotations.filter {
             it.typeRef != null && TypeReference(it.typeRef).sort == TypeReference.METHOD_FORMAL_PARAMETER
-                    && TypeReference(it.typeRef).formalParameterIndex == parameterIndex
+                && TypeReference(it.typeRef).formalParameterIndex == parameterIndex
         }
 
     override val description get() = methodInfo.desc

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/JcInstListBuilder.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/JcInstListBuilder.kt
@@ -77,7 +77,7 @@ class JcInstListBuilder(val method: JcMethod,val instList: JcInstList<JcRawInst>
             inst.lhv.let { unprocessedLhv ->
                 if (unprocessedLhv is JcRawLocalVar && unprocessedLhv.typeName == UNINIT_THIS) {
                     convertedLocalVars.getOrPut(unprocessedLhv) {
-                        JcRawLocalVar(unprocessedLhv.name, inst.rhv.typeName)
+                        JcRawLocalVar(unprocessedLhv.index, unprocessedLhv.name, inst.rhv.typeName)
                     }
                 } else {
                     unprocessedLhv
@@ -338,8 +338,8 @@ class JcInstListBuilder(val method: JcMethod,val instList: JcInstList<JcRawInst>
 
     override fun visitJcRawLocalVar(value: JcRawLocalVar): JcExpr =
         convertedLocalVars[value]?.let { replacementForLocalVar ->
-            JcLocalVar(replacementForLocalVar.name, replacementForLocalVar.typeName.asType())
-        } ?: JcLocalVar(value.name, value.typeName.asType())
+            JcLocalVar(replacementForLocalVar.index, replacementForLocalVar.name, replacementForLocalVar.typeName.asType())
+        } ?: JcLocalVar(value.index, value.name, value.typeName.asType())
 
     override fun visitJcRawFieldRef(value: JcRawFieldRef): JcExpr {
         val type = value.declaringClass.asType() as JcClassType

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/JcInstListImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/JcInstListImpl.kt
@@ -46,7 +46,6 @@ open class JcInstListImpl<INST>(
             else -> "  $it"
         }
     }
-
 }
 
 class JcMutableInstListImpl<INST>(instructions: List<INST>) : JcInstListImpl<INST>(instructions),

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/MethodInstructionsFeature.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/MethodInstructionsFeature.kt
@@ -32,7 +32,9 @@ import org.jacodb.impl.features.classpaths.AbstractJcInstResult.JcFlowGraphResul
 import org.jacodb.impl.features.classpaths.AbstractJcInstResult.JcInstListResultImpl
 import org.jacodb.impl.features.classpaths.AbstractJcInstResult.JcRawInstListResultImpl
 
-object MethodInstructionsFeature : JcMethodExtFeature {
+class MethodInstructionsFeature(
+    private val keepLocalVariableNames: Boolean
+) : JcMethodExtFeature {
 
     private val JcMethod.methodFeatures
         get() = enclosingClass.classpath.features?.filterIsInstance<JcInstExtFeature>().orEmpty()
@@ -50,7 +52,7 @@ object MethodInstructionsFeature : JcMethodExtFeature {
     }
 
     override fun rawInstList(method: JcMethod): JcMethodExtFeature.JcRawInstListResult {
-        val list: JcInstList<JcRawInst> = RawInstListBuilder(method, method.asmNode()).build()
+        val list: JcInstList<JcRawInst> = RawInstListBuilder(method, method.asmNode(), keepLocalVariableNames).build()
         return JcRawInstListResultImpl(method, method.methodFeatures.fold(list) { value, feature ->
             feature.transformRawInstList(method, value)
         })

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/virtual/JcVirtualMethod.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/virtual/JcVirtualMethod.kt
@@ -27,8 +27,8 @@ import org.jacodb.api.cfg.JcInst
 import org.jacodb.api.cfg.JcInstList
 import org.jacodb.api.cfg.JcRawInst
 import org.jacodb.impl.bytecode.JcDeclarationImpl
+import org.jacodb.impl.cfg.JcGraphImpl
 import org.jacodb.impl.cfg.JcInstListImpl
-import org.jacodb.impl.features.classpaths.MethodInstructionsFeature
 import org.objectweb.asm.Opcodes
 import org.objectweb.asm.tree.MethodNode
 
@@ -43,9 +43,7 @@ interface JcVirtualMethod : JcMethod {
     override val instList: JcInstList<JcInst>
         get() = JcInstListImpl(emptyList())
 
-    override fun flowGraph(): JcGraph {
-        return MethodInstructionsFeature.flowGraph(this).flowGraph
-    }
+    override fun flowGraph(): JcGraph = JcGraphImpl(this, instList.instructions)
 }
 
 open class JcVirtualParameter(

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/InstructionsTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/InstructionsTest.kt
@@ -61,9 +61,21 @@ class InstructionsTest : BaseInstructionsTest() {
         val instructions = method.instList.instructions
         val firstUse = instructions.indexOfFirst { it.callExpr?.method?.method == use }
         val assign = instructions[firstUse + 1] as JcAssignInst
-        assertEquals("%4", (assign.lhv as JcLocalVar).name)
-        assertEquals("%1", (assign.rhv as JcLocalVar).name)
+        assertEquals("b", (assign.lhv as JcLocalVar).name)
+        assertEquals("a", (assign.rhv as JcLocalVar).name)
     }
+
+    @Test
+    fun `invoke inst`() {
+        val clazz = cp.findClass<SimpleAlias1>()
+        val method = clazz.declaredMethods.first { it.name == "invoke" }
+        val instructions = method.instList.instructions
+        val usedArgumentExprs = instructions.filter { it.callExpr?.method?.method?.name == "println" }
+            .flatMap { it.callExpr?.args.orEmpty() }
+        val usedArgumentNames = usedArgumentExprs.map { (it as JcArgument).name }
+        assertEquals(listOf("i", "j", "b", "d"), usedArgumentNames)
+    }
+
 
     @Test
     fun `cmp insts`() {

--- a/jacodb-core/src/testFixtures/java/org/jacodb/testing/cfg/SimpleAlias1.java
+++ b/jacodb-core/src/testFixtures/java/org/jacodb/testing/cfg/SimpleAlias1.java
@@ -39,6 +39,13 @@ public class SimpleAlias1 {
         Benchmark.test("b",
                 "{allocId:1, mayAlias:[a,b], notMayAlias:[], mustAlias:[a,b], notMustAlias:[]}");
     }
+
+    public void invoke(int i, long j, byte b, double d) {
+        System.out.println(i);
+        System.out.println(j);
+        System.out.println(b);
+        System.out.println(d);
+    }
 }
 
 class A {

--- a/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/BaseTest.kt
+++ b/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/BaseTest.kt
@@ -85,6 +85,7 @@ open class WithDB(vararg features: Any) : JcDatabaseHolder {
             // persistent("D:\\work\\jacodb\\jcdb-index.db")
             loadByteCode(allClasspath)
             useProcessJavaRuntime()
+            keepLocalVariableNames()
             installFeatures(*dbFeatures.toTypedArray())
         }.also {
             it.awaitBackgroundJobs()
@@ -134,6 +135,7 @@ open class WithRestoredDB(vararg features: JcFeature<*, *>) : WithDB(*features) 
                 persistent(jdbcLocation)
                 loadByteCode(allClasspath)
                 useProcessJavaRuntime()
+                keepLocalVariableNames()
                 installFeatures(*dbFeatures.toTypedArray())
             }.also {
                 it.awaitBackgroundJobs()


### PR DESCRIPTION
For debug and test purposes, I need a feature to see original local variable names instead of stuff like `%0`, `%42`, `arg$13`, etc.

* Added setting `keepLocalVariableNames`
* `MethodInstructionsFeature` became class
* Modified `RawInstListBuilder` and `Simplifier`
* **IMPORTANT**: Added `index` field to `JcLocalVar`, `JcRawLocalVar`. 
* **IMPORTANT**: Now `name` field is ignored in `equals` and `hashCode` in `Jc(Raw)LocalVar` and `Jc(Raw)Argument` 