### PR TITLE
Flow-less summary storage

### DIFF
--- a/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/ifds/Producer.kt
+++ b/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/ifds/Producer.kt
@@ -1,0 +1,156 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jacodb.analysis.ifds
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+interface Producer<T> {
+    fun produce(event: T)
+    fun subscribe(consumer: Consumer<T>)
+}
+
+fun interface Consumer<in T> {
+    fun consume(event: T)
+}
+
+class SyncProducer<T> : Producer<T> {
+    private val consumers: MutableList<Consumer<T>> = mutableListOf()
+    private val events: MutableList<T> = mutableListOf()
+
+    @Synchronized
+    override fun produce(event: T) {
+        for (consumer in consumers) {
+            consumer.consume(event)
+        }
+        events.add(event)
+    }
+
+    @Synchronized
+    override fun subscribe(consumer: Consumer<T>) {
+        for (event in events) {
+            consumer.consume(event)
+        }
+        consumers.add(consumer)
+    }
+}
+
+sealed interface ConsList<out T> : Iterable<T>
+
+object Nil : ConsList<Nothing> {
+    override fun iterator(): Iterator<Nothing> = object : Iterator<Nothing> {
+        override fun hasNext(): Boolean = false
+        override fun next(): Nothing {
+            throw NoSuchElementException()
+        }
+    }
+
+    override fun toString(): String = javaClass.simpleName
+}
+
+data class Cons<out T>(
+    val value: T,
+    val tail: ConsList<T>,
+) : ConsList<T> {
+    override fun iterator(): Iterator<T> = Iter(this)
+
+    private class Iter<T>(private var list: ConsList<T>) : Iterator<T> {
+        override fun hasNext(): Boolean = list !is Nil
+
+        override fun next(): T = when (val list = list) {
+            is Nil -> throw NoSuchElementException()
+            is Cons -> {
+                val value = list.value
+                this.list = list.tail
+                value
+            }
+        }
+    }
+}
+
+class NonBlockingQueue<T> {
+    data class Node<T>(
+        val value: T,
+        @Volatile var next: Node<T>? = null,
+    )
+
+    var head: Node<T>? = null
+        private set
+    val tail: AtomicReference<Node<T>> = AtomicReference(head)
+    val size: AtomicInteger = AtomicInteger(0)
+
+    fun add(element: T) {
+        val node = Node(element)
+        var currentTail: Node<T>?
+        while (true) {
+            currentTail = tail.get()
+            if (tail.compareAndSet(currentTail, node)) break
+        }
+        if (currentTail != null) {
+            currentTail.next = node
+        } else {
+            head = node
+        }
+        size.incrementAndGet()
+    }
+}
+
+class ConcurrentProducer<T> : Producer<T> {
+    private var consumers: AtomicReference<ConsList<Consumer<T>>> = AtomicReference(Nil)
+    private val events: NonBlockingQueue<T> = NonBlockingQueue()
+
+    override fun produce(event: T) {
+        var currentConsumers: ConsList<Consumer<T>>
+        while (true) {
+            currentConsumers = consumers.get() ?: continue
+            if (consumers.compareAndSet(currentConsumers, null)) break
+        }
+
+        events.add(event)
+
+        try {
+            for (consumer in currentConsumers) {
+                consumer.consume(event)
+            }
+        } finally {
+            check(consumers.compareAndSet(null, currentConsumers))
+        }
+    }
+
+    override fun subscribe(consumer: Consumer<T>) {
+        var last: NonBlockingQueue.Node<T>? = null
+        while (true) {
+            val start = if (last != null) last.next else events.head
+            var current = start
+            while (current != null) {
+                last = current
+                consumer.consume(current.value)
+                current = current.next
+            }
+
+            val currentConsumers = consumers.get() ?: continue
+            if (!consumers.compareAndSet(currentConsumers, null)) continue
+            if (events.tail.get() === last) {
+                val newConsumers = Cons(consumer, currentConsumers)
+                check(consumers.compareAndSet(null, newConsumers))
+                break
+            } else {
+                check(consumers.compareAndSet(null, currentConsumers))
+            }
+        }
+    }
+}

--- a/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/ifds/Runner.kt
+++ b/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/ifds/Runner.kt
@@ -110,6 +110,7 @@ class UniRunner<Fact, Event>(
 
             // Add edge to worklist:
             workList.trySend(edge).getOrThrow()
+            manager.handleControlEvent(queueIsNotEmpty)
 
             return true
         }
@@ -122,7 +123,6 @@ class UniRunner<Fact, Event>(
             val edge = workList.tryReceive().getOrElse {
                 manager.handleControlEvent(queueIsEmpty)
                 val edge = workList.receive()
-                manager.handleControlEvent(queueIsNotEmpty)
                 edge
             }
             tabulationAlgorithmStep(edge, this@coroutineScope)

--- a/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/taint/TaintManager.kt
+++ b/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/taint/TaintManager.kt
@@ -33,7 +33,7 @@ import org.jacodb.analysis.ifds.IfdsResult
 import org.jacodb.analysis.ifds.Manager
 import org.jacodb.analysis.ifds.QueueEmptinessChanged
 import org.jacodb.analysis.ifds.SummaryEdge
-import org.jacodb.analysis.ifds.SummaryStorageImpl
+import org.jacodb.analysis.ifds.SummaryStorageWithFlows
 import org.jacodb.analysis.ifds.SummaryStorageWithProducers
 import org.jacodb.analysis.ifds.TraceGraph
 import org.jacodb.analysis.ifds.UniRunner
@@ -64,7 +64,7 @@ open class TaintManager(
     private val queueIsEmpty = ConcurrentHashMap<UnitType, Boolean>()
 
     private val summaryEdgesStorage = SummaryStorageWithProducers<SummaryEdge<TaintDomainFact>>()
-    private val vulnerabilitiesStorage = SummaryStorageImpl<TaintVulnerability>()
+    private val vulnerabilitiesStorage = SummaryStorageWithFlows<TaintVulnerability>()
 
     private val stopRendezvous = Channel<Unit>(Channel.RENDEZVOUS)
 

--- a/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/taint/TaintManager.kt
+++ b/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/taint/TaintManager.kt
@@ -22,8 +22,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -34,7 +32,9 @@ import org.jacodb.analysis.ifds.ControlEvent
 import org.jacodb.analysis.ifds.IfdsResult
 import org.jacodb.analysis.ifds.Manager
 import org.jacodb.analysis.ifds.QueueEmptinessChanged
+import org.jacodb.analysis.ifds.SummaryEdge
 import org.jacodb.analysis.ifds.SummaryStorageImpl
+import org.jacodb.analysis.ifds.SummaryStorageWithProducers
 import org.jacodb.analysis.ifds.TraceGraph
 import org.jacodb.analysis.ifds.UniRunner
 import org.jacodb.analysis.ifds.UnitResolver
@@ -63,7 +63,7 @@ open class TaintManager(
     protected val runnerForUnit: MutableMap<UnitType, TaintRunner> = hashMapOf()
     private val queueIsEmpty = ConcurrentHashMap<UnitType, Boolean>()
 
-    private val summaryEdgesStorage = SummaryStorageImpl<TaintSummaryEdge>()
+    private val summaryEdgesStorage = SummaryStorageWithProducers<SummaryEdge<TaintDomainFact>>()
     private val vulnerabilitiesStorage = SummaryStorageImpl<TaintVulnerability>()
 
     private val stopRendezvous = Channel<Unit>(Channel.RENDEZVOUS)
@@ -277,10 +277,7 @@ open class TaintManager(
         scope: CoroutineScope,
         handler: (TaintEdge) -> Unit,
     ) {
-        summaryEdgesStorage
-            .getFacts(method)
-            .onEach { handler(it.edge) }
-            .launchIn(scope)
+        summaryEdgesStorage.subscribe(method) { handler(it.edge) }
     }
 
     fun vulnerabilityTraceGraph(vulnerability: TaintVulnerability): TraceGraph<TaintDomainFact> {

--- a/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/unused/UnusedVariableManager.kt
+++ b/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/unused/UnusedVariableManager.kt
@@ -34,7 +34,7 @@ import org.jacodb.analysis.ifds.Edge
 import org.jacodb.analysis.ifds.Manager
 import org.jacodb.analysis.ifds.QueueEmptinessChanged
 import org.jacodb.analysis.ifds.Runner
-import org.jacodb.analysis.ifds.SummaryStorageImpl
+import org.jacodb.analysis.ifds.SummaryStorageWithFlows
 import org.jacodb.analysis.ifds.UniRunner
 import org.jacodb.analysis.ifds.UnitResolver
 import org.jacodb.analysis.ifds.UnitType
@@ -62,8 +62,8 @@ class UnusedVariableManager(
     private val runnerForUnit: MutableMap<UnitType, Runner<UnusedVariableDomainFact>> = hashMapOf()
     private val queueIsEmpty = ConcurrentHashMap<UnitType, Boolean>()
 
-    private val summaryEdgesStorage = SummaryStorageImpl<UnusedVariableSummaryEdge>()
-    private val vulnerabilitiesStorage = SummaryStorageImpl<UnusedVariableVulnerability>()
+    private val summaryEdgesStorage = SummaryStorageWithFlows<UnusedVariableSummaryEdge>()
+    private val vulnerabilitiesStorage = SummaryStorageWithFlows<UnusedVariableVulnerability>()
 
     private val stopRendezvous = Channel<Unit>(Channel.RENDEZVOUS)
 

--- a/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/unused/UnusedVariableManager.kt
+++ b/jacodb-analysis/src/main/kotlin/org/jacodb/analysis/unused/UnusedVariableManager.kt
@@ -63,7 +63,6 @@ class UnusedVariableManager(
     private val queueIsEmpty = ConcurrentHashMap<UnitType, Boolean>()
 
     private val summaryEdgesStorage = SummaryStorageWithFlows<UnusedVariableSummaryEdge>()
-    private val vulnerabilitiesStorage = SummaryStorageWithFlows<UnusedVariableVulnerability>()
 
     private val stopRendezvous = Channel<Unit>(Channel.RENDEZVOUS)
 

--- a/jacodb-analysis/src/test/resources/additional.json
+++ b/jacodb-analysis/src/test/resources/additional.json
@@ -603,5 +603,46 @@
         }
       }
     ]
+  },
+  {
+    "_": "MethodSource",
+    "methodInfo": {
+      "cls": {
+        "classNameMatcher": {
+          "_": "NameIsEqualTo",
+          "name": "Properties"
+        },
+        "packageMatcher": {
+          "_": "NameIsEqualTo",
+          "name": "java.util"
+        }
+      },
+      "functionName": {
+        "_": "NameIsEqualTo",
+        "name": "getProperty"
+      },
+      "applyToOverrides": true,
+      "exclude": [],
+      "functionLabel": null,
+      "modifier": -1,
+      "parametersMatchers": [],
+      "returnTypeMatcher": {
+        "_": "AnyTypeMatches"
+      }
+    },
+    "condition": {
+      "_": "ConstantTrue"
+    },
+    "actionsAfter": [
+      {
+        "_": "AssignMark",
+        "position": {
+          "_": "Result"
+        },
+        "mark": {
+          "name": "PROPERTY"
+        }
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This PR proposes to add a summary storage without Flow's, which allows for deterministic (non-asynchronous!) subscriptions on summary edges.
Ultimately, this enables us to use `MethodUnitResolver` without any doubts, which currently is not very possible to due the fact that method-bound runners might die (i.e. might be killed by the manager) due to their queue exhaustion before the subscription on summary edges will be handled by the separate spawned coroutine (`launch` + `SharedFlow::collect`).

TODO:
- consider renaming the existing summary storage impl
- refine the interface of the summary storage
- add tests utilizing the `MethodUnitResolver`