### PR TITLE
Ir Fixes

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -4,7 +4,7 @@ import org.gradle.plugin.use.PluginDependenciesSpec
 
 object Versions {
     const val antlr = "4.9.3"
-    const val asm = "9.5"
+    const val asm = "9.7"
     const val dokka = "1.7.20"
     const val gradle_download = "5.3.0"
     const val gradle_versions = "0.47.0"
@@ -42,6 +42,9 @@ object Versions {
     const val xodus = "2.0.1"
     const val rocks_db = "9.1.1"
     const val lmdb_java = "0.9.0"
+
+    // libs for tests only
+    const val jgit_test_only_version = "5.9.0.202009080501-r"
 }
 
 fun dep(group: String, name: String, version: String): String = "$group:$name:$version"
@@ -330,6 +333,12 @@ object Libs {
         group = "org.rocksdb",
         name = "rocksdbjni",
         version = Versions.rocks_db
+    )
+
+    val jgit_test_only_lib = dep(
+        group = "org.eclipse.jgit",
+        name = "org.eclipse.jgit",
+        version = Versions.jgit_test_only_version
     )
 }
 

--- a/jacodb-core/build.gradle.kts
+++ b/jacodb-core/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     testFixturesImplementation(Libs.guava)
     testFixturesImplementation(Libs.jetbrains_annotations)
     testFixturesImplementation(Libs.kotlinx_coroutines_core)
+    testFixturesImplementation(Libs.jgit_test_only_lib)
 }
 
 tasks {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/types/substition/RecursiveJvmTypeVisitor.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/types/substition/RecursiveJvmTypeVisitor.kt
@@ -105,7 +105,7 @@ internal val Map<String, JvmTypeParameterDeclaration>.fixDeclarationVisitor: Rec
         return object : RecursiveJvmTypeVisitor {
 
             override fun visitTypeVariable(type: JvmTypeVariable, context: VisitorContext): JvmType {
-                type.declaration = declarations[type.symbol]!!
+                type.declaration = declarations[type.symbol]
                 return type
             }
         }

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/BaseInstructionsTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/BaseInstructionsTest.kt
@@ -25,6 +25,7 @@ import org.jacodb.api.jvm.ext.packageName
 import org.jacodb.impl.bytecode.JcDatabaseClassWriter
 import org.jacodb.impl.cfg.MethodNodeBuilder
 import org.jacodb.impl.features.hierarchyExt
+import org.jacodb.impl.fs.className
 import org.jacodb.testing.BaseTest
 import org.jacodb.testing.WithGlobalDB
 import org.junit.jupiter.api.Assertions
@@ -77,7 +78,10 @@ abstract class BaseInstructionsTest : BaseTest() {
             classNode.methods = klass.declaredMethods
                 .filter { it.enclosingClass == klass }
                 .map {
-                    if (it.isAbstract || it.name.contains("$\$forInline")) {
+                    if (it.isAbstract ||
+                        it.name.contains("$\$forInline")||
+                        it.name.contains("lambda$") ||
+                        it.name.contains("stringConcat$")) {
                         it.asmNode()
                     } else {
                         try {
@@ -91,10 +95,12 @@ abstract class BaseInstructionsTest : BaseTest() {
                             }
                             val graph = it.flowGraph()
                             if (!it.enclosingClass.isKotlin) {
-                                val methodMsg = "$it should have line number"
                                 if (validateLineNumbers) {
+                                    val methodMsg = "$it should have line number"
                                     graph.instructions.forEach { inst ->
-                                        Assertions.assertTrue(inst.location.lineNumber > 0, methodMsg)
+                                        Assertions.assertTrue(
+                                            inst.location.lineNumber > 0, methodMsg
+                                        )
                                     }
                                 }
                             }

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/IRTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/IRTest.kt
@@ -66,12 +66,14 @@ import org.jacodb.testing.WithDB
 import org.jacodb.testing.WithRAMDB
 import org.jacodb.testing.asmLib
 import org.jacodb.testing.guavaLib
+import org.jacodb.testing.jgitLib
 import org.jacodb.testing.kotlinStdLib
 import org.jacodb.testing.kotlinxCoroutines
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import java.io.File
@@ -341,6 +343,12 @@ abstract class IRTest : BaseInstructionsTest() {
     @Test
     fun `get ir of guava`() {
         runAlongLib(guavaLib)
+    }
+
+    @Test
+    @Disabled
+    fun `get ir of jgit`() {
+        runAlongLib(jgitLib)
     }
 
     @Test

--- a/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/LibrariesMixin.kt
+++ b/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/LibrariesMixin.kt
@@ -33,6 +33,14 @@ val guavaLib: File
         }
     }
 
+val jgitLib: File
+    get() {
+        val jgitUrl = classpath.first { it.contains("jgit-") }
+        return File(jgitUrl).also {
+            Assertions.assertTrue(it.isFile && it.exists())
+        }
+    }
+
 val asmLib: File
     get() {
         val asmUrl = classpath.first { it.contains("${File.separator}asm${File.separator}") }


### PR DESCRIPTION
In BaseInstructionsTest, avoid doing  flow graph checking for methods having "StringConcat$" substring in their names in addition to "$$forInline" and "lambda$".

[jacodb-core] Fix minor review points

[build] Upgrade org.ow2.asm dependencies to version 9.7

[jacodb-core] IR: allow lambdas have line number equal to 0

[jacodb-core] IR: fix frame preparation for label node having several unprocessed predecessors

If a label instruction node has several unprocessed predecessors (say, jump instruction nodes), their frames are all equal to `null`. Process this case separately on preparation of frame for the label instruction node.