### PR TITLE
Fix ArkAnalyzer branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -134,8 +134,10 @@ jobs:
 
       - name: Set up ArkAnalyzer
         run: |
-          git clone --depth=1 --branch=jacodb https://gitee.com/Lipenx/arkanalyzer
+          git clone https://gitee.com/openharmony-sig/arkanalyzer
           cd arkanalyzer
+          # checkout master on 2024-07-17
+          git switch --detach a9d9fd6070fce5896d8e760ed7fd175b62b16605
           npm install
           npm run build
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Set up ArkAnalyzer
         run: |
-          git clone --depth=1 --branch=lipen/json-printer https://gitee.com/Lipenx/arkanalyzer
+          git clone --depth=1 --branch=jacodb https://gitee.com/Lipenx/arkanalyzer
           cd arkanalyzer
           npm install
           npm run build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -134,10 +134,12 @@ jobs:
 
       - name: Set up ArkAnalyzer
         run: |
-          git clone https://gitee.com/openharmony-sig/arkanalyzer
+          git clone --depth=1 https://gitee.com/openharmony-sig/arkanalyzer
           cd arkanalyzer
           # checkout master on 2024-07-17
-          git switch --detach a9d9fd6070fce5896d8e760ed7fd175b62b16605
+          rev=a9d9fd6070fce5896d8e760ed7fd175b62b16605
+          git fetch --depth=1 origin $rev
+          git switch --detach $rev
           npm install
           npm run build
 


### PR DESCRIPTION
This PR fixes GHA workflow by using the specific commit of ArkAnalyzer.

Before that, we have used a specific branch of arkanalyzer's fork that contained the required `JsonPrinter`. Lately, this branch was finally merged into ArkAnalyzer's master. From now on, we are going to depend on the specific commit on the master branch of arkanalyzer, and regularly update it.