### PR TITLE
Ensure EtsIR is more three-address-like

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
@@ -41,6 +41,7 @@ import org.jacodb.ets.base.EtsDivExpr
 import org.jacodb.ets.base.EtsEntity
 import org.jacodb.ets.base.EtsEqExpr
 import org.jacodb.ets.base.EtsExpExpr
+import org.jacodb.ets.base.EtsExpr
 import org.jacodb.ets.base.EtsFieldRef
 import org.jacodb.ets.base.EtsGotoStmt
 import org.jacodb.ets.base.EtsGtEqExpr
@@ -129,6 +130,10 @@ class EtsMethodBuilder(
 
     private var freeTempLocal: Int = 0
 
+    private fun newTempLocal(type: EtsType): EtsLocal {
+        return EtsLocal("_tmp${freeTempLocal++}", type)
+    }
+
     private fun loc(): EtsInstLocation {
         return EtsInstLocation(etsMethod, currentStmts.size)
     }
@@ -148,7 +153,7 @@ class EtsMethodBuilder(
         // if (entity is EtsCastExpr) return entity
 
         if (entity is EtsExpr || entity is EtsFieldRef || entity is EtsArrayAccess) {
-            val newLocal = EtsLocal("_tmp${freeTempLocal++}", entity.type)
+            val newLocal = newTempLocal(entity.type)
             currentStmts += EtsAssignStmt(
                 location = loc(),
                 lhv = newLocal,

--- a/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsFileTest.kt
+++ b/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsFileTest.kt
@@ -53,14 +53,14 @@ class EtsFileTest {
     fun `test etsFile on TypeMismatch`() {
         val etsFile = load("etsir/samples/TypeMismatch")
         etsFile.classes.forEach { cls ->
-            cls.methods.forEach { etsMethod ->
-                when (etsMethod.name) {
+            cls.methods.forEach { method ->
+                when (method.name) {
                     "add" -> {
-                        Assertions.assertEquals(9, etsMethod.cfg.instructions.size)
+                        Assertions.assertEquals(11, method.cfg.instructions.size)
                     }
 
                     "main" -> {
-                        Assertions.assertEquals(4, etsMethod.cfg.instructions.size)
+                        Assertions.assertEquals(5, method.cfg.instructions.size)
                     }
                 }
             }


### PR DESCRIPTION
This PR proposes to ensure that EtsIR is three-address code by adding the `ensureOneAddress` function to `ArkIR -> EtsIR` conversion process (in `Convert.kt`). This function extracts nested expressions and field/array references by assigning them to temp locals. In fact, the proposed functionality was already present here, but was duplicated in multiple places. This PR both generalizes it in one place, and also handles nested RHVs in `AssignStmt`.