### PR TITLE
Extract interface EtsApplicationGraph

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/graph/EtsApplicationGraph.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/graph/EtsApplicationGraph.kt
@@ -17,15 +17,18 @@
 package org.jacodb.ets.graph
 
 import org.jacodb.api.common.analysis.ApplicationGraph
-import org.jacodb.ets.base.EtsCallStmt
 import org.jacodb.ets.base.EtsStmt
 import org.jacodb.ets.model.EtsFile
 import org.jacodb.ets.model.EtsMethod
 import org.jacodb.ets.utils.callExpr
 
-class EtsApplicationGraph(
-    val cp: EtsFile,
-) : ApplicationGraph<EtsMethod, EtsStmt> {
+interface EtsApplicationGraph : ApplicationGraph<EtsMethod, EtsStmt> {
+    val cp: EtsFile
+}
+
+class EtsApplicationGraphImpl(
+    override val cp: EtsFile,
+) : EtsApplicationGraph {
 
     override fun predecessors(node: EtsStmt): Sequence<EtsStmt> {
         val graph = node.method.flowGraph()
@@ -48,12 +51,14 @@ class EtsApplicationGraph(
     }
 
     override fun callers(method: EtsMethod): Sequence<EtsStmt> {
-        return cp.classes.asSequence()
-            .flatMap { it.methods }
-            .flatMap { it.cfg.instructions }
-            .filterIsInstance<EtsCallStmt>()
-            // TODO: consider comparing only by name
-            .filter { it.expr.method == method.signature }
+        // Note: currently, nobody uses `callers`, so if is safe to disable it for now.
+        // Note: comparing methods by signature may be incorrect, and comparing only by name fails for constructors.
+        TODO("disabled for now, need re-design")
+        // return cp.classes.asSequence()
+        //     .flatMap { it.methods }
+        //     .flatMap { it.cfg.instructions }
+        //     .filterIsInstance<EtsCallStmt>()
+        //     .filter { it.expr.method == method.signature }
     }
 
     override fun entryPoints(method: EtsMethod): Sequence<EtsStmt> {

--- a/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsIfds.kt
+++ b/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsIfds.kt
@@ -24,7 +24,7 @@ import org.jacodb.analysis.taint.TaintAnalysisOptions
 import org.jacodb.analysis.taint.TaintManager
 import org.jacodb.analysis.util.EtsTraits
 import org.jacodb.ets.base.EtsStmt
-import org.jacodb.ets.graph.EtsApplicationGraph
+import org.jacodb.ets.graph.EtsApplicationGraphImpl
 import org.jacodb.ets.model.EtsFile
 import org.jacodb.ets.model.EtsMethod
 import org.jacodb.taint.configuration.Argument
@@ -43,9 +43,6 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledIf
-import java.io.File
-import java.nio.file.Files
-import java.nio.file.Paths
 import kotlin.io.path.exists
 import kotlin.io.path.toPath
 import kotlin.time.Duration.Companion.seconds
@@ -71,7 +68,7 @@ class EtsIfds {
     @Test
     fun `test taint analysis on MethodCollision`() {
         val project = loadSample("MethodCollision")
-        val graph = EtsApplicationGraph(project)
+        val graph = EtsApplicationGraphImpl(project)
         val unitResolver = UnitResolver<EtsMethod> { SingletonUnit }
         val getConfigForMethod: ForwardTaintFlowFunctions<EtsMethod, EtsStmt>.(EtsMethod) -> List<TaintConfigurationItem>? =
             { method ->
@@ -115,7 +112,7 @@ class EtsIfds {
     @Test
     fun `test taint analysis on TypeMismatch`() {
         val project = loadSample("TypeMismatch")
-        val graph = EtsApplicationGraph(project)
+        val graph = EtsApplicationGraphImpl(project)
         val unitResolver = UnitResolver<EtsMethod> { SingletonUnit }
         val getConfigForMethod: ForwardTaintFlowFunctions<EtsMethod, EtsStmt>.(EtsMethod) -> List<TaintConfigurationItem>? =
             { method ->
@@ -160,7 +157,7 @@ class EtsIfds {
     @Test
     fun `test taint analysis on DataFlowSecurity`() {
         val project = loadSample("DataFlowSecurity")
-        val graph = EtsApplicationGraph(project)
+        val graph = EtsApplicationGraphImpl(project)
         val unitResolver = UnitResolver<EtsMethod> { SingletonUnit }
         val getConfigForMethod: ForwardTaintFlowFunctions<EtsMethod, EtsStmt>.(EtsMethod) -> List<TaintConfigurationItem>? =
             { method ->
@@ -225,7 +222,7 @@ class EtsIfds {
     @Test
     fun `test taint analysis on case1 - untrusted loop bound scenario`() {
         val project = loadSample("cases/case1")
-        val graph = EtsApplicationGraph(project)
+        val graph = EtsApplicationGraphImpl(project)
         val unitResolver = UnitResolver<EtsMethod> { SingletonUnit }
         val getConfigForMethod: ForwardTaintFlowFunctions<EtsMethod, EtsStmt>.(EtsMethod) -> List<TaintConfigurationItem>? =
             { method ->
@@ -262,7 +259,7 @@ class EtsIfds {
     @Test
     fun `test taint analysis on case2 - untrusted array buffer size scenario`() {
         val project = loadSample("cases/case2")
-        val graph = EtsApplicationGraph(project)
+        val graph = EtsApplicationGraphImpl(project)
         val unitResolver = UnitResolver<EtsMethod> { SingletonUnit }
         val getConfigForMethod: ForwardTaintFlowFunctions<EtsMethod, EtsStmt>.(EtsMethod) -> List<TaintConfigurationItem>? =
             { method ->
@@ -300,7 +297,7 @@ class EtsIfds {
     @Test
     fun `test taint analysis on case3 - send plain information with sensitive data`() {
         val project = loadSample("cases/case3")
-        val graph = EtsApplicationGraph(project)
+        val graph = EtsApplicationGraphImpl(project)
         val unitResolver = UnitResolver<EtsMethod> { SingletonUnit }
         val getConfigForMethod: ForwardTaintFlowFunctions<EtsMethod, EtsStmt>.(EtsMethod) -> List<TaintConfigurationItem>? =
             { method ->
@@ -344,7 +341,7 @@ class EtsIfds {
     @Test
     fun `test taint analysis on AccountManager`() {
         val project = loadEtsFileFromResource("/etsir/project1/entry/src/main/ets/base/account/AccountManager.ts.json")
-        val graph = EtsApplicationGraph(project)
+        val graph = EtsApplicationGraphImpl(project)
         val unitResolver = UnitResolver<EtsMethod> { SingletonUnit }
         val getConfigForMethod: ForwardTaintFlowFunctions<EtsMethod, EtsStmt>.(EtsMethod) -> List<TaintConfigurationItem>? =
             { method ->

--- a/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsProjectAnalysis.kt
+++ b/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsProjectAnalysis.kt
@@ -26,7 +26,7 @@ import org.jacodb.analysis.taint.TaintVulnerability
 import org.jacodb.analysis.util.EtsTraits
 import org.jacodb.analysis.util.getPathEdges
 import org.jacodb.ets.base.EtsStmt
-import org.jacodb.ets.graph.EtsApplicationGraph
+import org.jacodb.ets.graph.EtsApplicationGraphImpl
 import org.jacodb.ets.model.EtsFile
 import org.jacodb.ets.model.EtsMethod
 import org.junit.jupiter.api.Test
@@ -136,7 +136,7 @@ class EtsProjectAnalysis {
     }
 
     private fun runAnalysis(project: EtsFile) {
-        val graph = EtsApplicationGraph(project)
+        val graph = EtsApplicationGraphImpl(project)
         val unitResolver = UnitResolver<EtsMethod> { SingletonUnit }
         val manager = TaintManager(
             graph = graph,

--- a/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsTaintAnalysisTest.kt
+++ b/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsTaintAnalysisTest.kt
@@ -23,7 +23,7 @@ import org.jacodb.analysis.taint.ForwardTaintFlowFunctions
 import org.jacodb.analysis.taint.TaintManager
 import org.jacodb.analysis.util.EtsTraits
 import org.jacodb.ets.base.EtsStmt
-import org.jacodb.ets.graph.EtsApplicationGraph
+import org.jacodb.ets.graph.EtsApplicationGraphImpl
 import org.jacodb.ets.model.EtsFile
 import org.jacodb.ets.model.EtsMethod
 import org.jacodb.taint.configuration.Argument
@@ -103,7 +103,7 @@ class EtsTaintAnalysisTest {
     }
 
     fun runTaintAnalysis(etsFile: EtsFile) {
-        val graph = EtsApplicationGraph(etsFile)
+        val graph = EtsApplicationGraphImpl(etsFile)
         val unitResolver = UnitResolver<EtsMethod> { SingletonUnit }
 
         val manager = TaintManager(


### PR DESCRIPTION
This PR introduces an interface `EtsApplicationGraph : ApplicationGraph<EtsMethod, EtsStmt>` and renames the existing implementation class to `EtsApplicationGraphImpl`.

By extracting the interface, we enable the creation of wrapper implementations, such as:
```kotlin
class MyGraph(private val graph: EtsApplicationGraph) : EtsApplicationGraph by graph {
    // Additional functionality
}
```
This allows wrappers to implement the same interface, making it simpler for users to access the `cp` property of `EtsApplicationGraph`.