### PR TITLE
Add hashCode for EtsClassSignature

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/EtsSignature.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/EtsSignature.kt
@@ -72,6 +72,11 @@ data class EtsClassSignature(
         if (other !is EtsClassSignature) return false
         return this.name == other.name && this.file == other.file
     }
+
+    override fun hashCode(): Int {
+        return name.hashCode()
+    }
+
 }
 
 data class EtsFieldSignature(


### PR DESCRIPTION
This PR adds `hashCode()` impl for `EtsClassSignature` which already overrides `equals`.