### PR TITLE
Fix locations in intermediate statements 

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
@@ -180,48 +180,72 @@ class EtsMethodBuilder(
                 }
             }
 
-            is NopStmtDto -> EtsNopStmt(location = loc())
+            is NopStmtDto -> {
+                EtsNopStmt(location = loc())
+            }
 
-            is AssignStmtDto -> EtsAssignStmt(
-                location = loc(),
-                lhv = convertToEtsEntity(stmt.left) as EtsValue,
-                rhv = ensureOneAddress(convertToEtsEntity(stmt.right)),
-            )
-
-            is CallStmtDto -> EtsCallStmt(
-                location = loc(),
-                expr = convertToEtsEntity(stmt.expr) as EtsCallExpr,
-            )
-
-            is ReturnStmtDto -> {
-                EtsReturnStmt(
+            is AssignStmtDto -> {
+                val lhv = convertToEtsEntity(stmt.left) as EtsValue
+                val rhv = ensureOneAddress(convertToEtsEntity(stmt.right))
+                EtsAssignStmt(
                     location = loc(),
-                    returnValue = ensureOneAddress(convertToEtsEntity(stmt.arg)),
+                    lhv = lhv,
+                    rhv = rhv,
                 )
             }
 
-            is ReturnVoidStmtDto -> EtsReturnStmt(
-                location = loc(),
-                returnValue = null,
-            )
+            is CallStmtDto -> {
+                val expr = convertToEtsEntity(stmt.expr) as EtsCallExpr
+                EtsCallStmt(
+                    location = loc(),
+                    expr = expr,
+                )
+            }
 
-            is ThrowStmtDto -> EtsThrowStmt(
-                location = loc(),
-                arg = convertToEtsEntity(stmt.arg),
-            )
+            is ReturnStmtDto -> {
+                val returnValue = ensureOneAddress(convertToEtsEntity(stmt.arg))
+                EtsReturnStmt(
+                    location = loc(),
+                    returnValue = returnValue,
+                )
+            }
 
-            is GotoStmtDto -> EtsGotoStmt(location = loc())
+            is ReturnVoidStmtDto -> {
+                EtsReturnStmt(
+                    location = loc(),
+                    returnValue = null,
+                )
+            }
 
-            is IfStmtDto -> EtsIfStmt(
-                location = loc(),
-                condition = convertToEtsEntity(stmt.condition),
-            )
+            is ThrowStmtDto -> {
+                val arg = convertToEtsEntity(stmt.arg)
+                EtsThrowStmt(
+                    location = loc(),
+                    arg = arg,
+                )
+            }
 
-            is SwitchStmtDto -> EtsSwitchStmt(
-                location = loc(),
-                arg = convertToEtsEntity(stmt.arg),
-                cases = stmt.cases.map { convertToEtsEntity(it) },
-            )
+            is GotoStmtDto -> {
+                EtsGotoStmt(location = loc())
+            }
+
+            is IfStmtDto -> {
+                val condition = convertToEtsEntity(stmt.condition)
+                EtsIfStmt(
+                    location = loc(),
+                    condition = condition,
+                )
+            }
+
+            is SwitchStmtDto -> {
+                val arg = convertToEtsEntity(stmt.arg)
+                val cases = stmt.cases.map { convertToEtsEntity(it) }
+                EtsSwitchStmt(
+                    location = loc(),
+                    arg = arg,
+                    cases = cases,
+                )
+            }
 
             // else -> error("Unknown Stmt: $stmt")
         }

--- a/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsFromJsonTest.kt
+++ b/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsFromJsonTest.kt
@@ -34,6 +34,7 @@ import org.jacodb.ets.dto.LocalDto
 import org.jacodb.ets.dto.MethodDto
 import org.jacodb.ets.dto.ModifierDto
 import org.jacodb.ets.dto.NumberTypeDto
+import org.jacodb.ets.dto.ReturnVoidStmtDto
 import org.jacodb.ets.dto.StmtDto
 import org.jacodb.ets.dto.convertToEtsFile
 import org.jacodb.ets.dto.convertToEtsMethod
@@ -133,9 +134,7 @@ class EtsFromJsonTest {
         """.trimIndent()
         val stmtDto = Json.decodeFromString<StmtDto>(jsonString)
         println("stmtDto = $stmtDto")
-        val ctx = EtsMethodBuilder(defaultSignature)
-        val stmt = ctx.convertToEtsStmt(stmtDto)
-        Assertions.assertEquals(EtsReturnStmt(EtsInstLocation(ctx.etsMethod, 0), null), stmt)
+        Assertions.assertEquals(ReturnVoidStmtDto, stmtDto)
     }
 
     @Test


### PR DESCRIPTION
This PR fixes some spurious locations mismatches by extracting the recursive calls (such as `EtsAssignStmt(location = loc(), lhv = <recurse>, rhv = <recurse>)`) with `ensureOneAddress` inside them. Without extracting these sub-expressions, `loc()` produces a location that might be "reused" by another `loc()` call inside `ensureOneAddress` (which creates extra assignment statement for complex expressions, thus allocates and fills a location). The proper way of doing it is to ensure that `lhv` and `rhv` are computed (and all necessary extra statements are already created and put inside `currentStmts`) *before* calling `loc()` for the newly created statement.
In fact, not all extractions that were made in this PR are strictly necessary for the correctness, but I just made the code changes uniform and consistent.