### PR TITLE
IR fixes and features improvement

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -3,7 +3,7 @@
 import org.gradle.plugin.use.PluginDependenciesSpec
 
 object Versions {
-    const val asm = "9.7"
+    const val asm = "9.6"
     const val dokka = "1.7.20"
     const val gradle_download = "5.3.0"
     const val gradle_versions = "0.47.0"
@@ -22,13 +22,13 @@ object Versions {
     const val jooq = "3.14.16"
     const val juliet = "1.3.2"
     const val junit = "5.9.2"
-    const val kotlin = "1.7.21"
+    const val kotlin = "1.9.25"
     const val kotlin_logging = "1.8.3"
     const val kotlinx_benchmark = "0.4.6"
     const val kotlinx_cli = "0.3.5"
     const val kotlinx_collections_immutable = "0.3.5"
     const val kotlinx_coroutines = "1.6.4"
-    const val kotlinx_metadata = "0.5.0"
+    const val kotlinx_metadata = "0.9.0"
     const val kotlinx_serialization = "1.4.1"
     const val licenser = "0.6.1"
     const val mockk = "1.13.3"

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/JcDatabaseImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/JcDatabaseImpl.kt
@@ -23,7 +23,7 @@ import org.jacodb.impl.features.classpaths.KotlinMetadata
 import org.jacodb.impl.features.classpaths.MethodInstructionsFeature
 import org.jacodb.impl.fs.JavaRuntime
 import org.jacodb.impl.fs.asByteCodeLocation
-import org.jacodb.impl.fs.filterExisted
+import org.jacodb.impl.fs.filterExisting
 import org.jacodb.impl.fs.lazySources
 import org.jacodb.impl.fs.sources
 import org.jacodb.impl.storage.SQLITE_DATABASE_PERSISTENCE_SPI
@@ -88,8 +88,8 @@ class JcDatabaseImpl(
 
     override suspend fun classpath(dirOrJars: List<File>, features: List<JcClasspathFeature>?): JcClasspath {
         assertNotClosed()
-        val existedLocations = dirOrJars.filterExisted().map { it.asByteCodeLocation(javaRuntime.version) }
-        val processed = locationsRegistry.registerIfNeeded(existedLocations.toList())
+        val existingLocations = dirOrJars.filterExisting().map { it.asByteCodeLocation(javaRuntime.version) }
+        val processed = locationsRegistry.registerIfNeeded(existingLocations)
             .also { it.new.process(true) }.registered + locationsRegistry.runtimeLocations
         return classpathOf(processed, features)
     }
@@ -123,7 +123,7 @@ class JcDatabaseImpl(
 
     override suspend fun load(dirOrJars: List<File>) = apply {
         assertNotClosed()
-        loadLocations(dirOrJars.filterExisted().map { it.asByteCodeLocation(javaRuntime.version) })
+        loadLocations(dirOrJars.filterExisting().map { it.asByteCodeLocation(javaRuntime.version) })
     }
 
     override suspend fun loadLocations(locations: List<JcByteCodeLocation>) = apply {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/bytecode/KMetadata.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/bytecode/KMetadata.kt
@@ -16,7 +16,6 @@
 
 package org.jacodb.impl.bytecode
 
-import kotlinx.metadata.Flag
 import kotlinx.metadata.KmConstructor
 import kotlinx.metadata.KmFunction
 import kotlinx.metadata.KmType
@@ -40,11 +39,11 @@ val JcClassOrInterface.kMetadata: KotlinMetadataHolder?
 
 val JcMethod.kmFunction: KmFunction?
     get() =
-        enclosingClass.kMetadata?.functions?.firstOrNull { it.signature?.name == name && it.signature?.desc == description }
+        enclosingClass.kMetadata?.functions?.firstOrNull { it.signature?.name == name && it.signature?.descriptor == description }
 
 val JcMethod.kmConstructor: KmConstructor?
     get() =
-        enclosingClass.kMetadata?.constructors?.firstOrNull { it.signature?.name == name && it.signature?.desc == description }
+        enclosingClass.kMetadata?.constructors?.firstOrNull { it.signature?.name == name && it.signature?.descriptor == description }
 
 val JcParameter.kmParameter: KmValueParameter?
     get() {
@@ -84,6 +83,3 @@ val JcField.kmType: KmType?
 val JcMethod.kmReturnType: KmType?
     get() =
         kmFunction?.returnType
-
-val KmType.isNullable: Boolean
-    get() = Flag.Type.IS_NULLABLE(flags)

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/types.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/cfg/util/types.kt
@@ -57,12 +57,7 @@ val TypeName.isPrimitive get() = PredefinedPrimitives.matches(typeName)
 val TypeName.isArray get() = typeName.endsWith("[]")
 val TypeName.isClass get() = !isPrimitive && !isArray
 
-internal val TypeName.isDWord
-    get() = when (typeName) {
-        PredefinedPrimitives.Long -> true
-        PredefinedPrimitives.Double -> true
-        else -> false
-    }
+internal val TypeName.isDWord get() = typeName == PredefinedPrimitives.Long || typeName == PredefinedPrimitives.Double
 
 internal fun String.typeName(): TypeName = TypeNameImpl(this.jcdbName())
 internal fun TypeName.asArray(dimensions: Int = 1) = "$typeName${"[]".repeat(dimensions)}".typeName()

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/features/BuilderExtension.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/features/BuilderExtension.kt
@@ -41,10 +41,14 @@ class BuildersExtension(private val classpath: JcClasspath, private val hierarch
         }
         val syncQuery = Builders.syncQuery(classpath, names)
         return syncQuery.mapNotNull { response ->
-            val foundClass = classpath.toJcClass(response.source)
+            val responseSource = response.source
+            val foundClass = classpath.toJcClass(responseSource)
             val type = foundClass.toType()
             foundClass.declaredMethods[response.methodOffset].takeIf { method ->
-                type.declaredMethods.first { it.method == method }.parameters.all { param ->
+                val typedMethod = type.declaredMethods.firstOrNull {
+                    it.method == method
+                }
+                typedMethod != null && typedMethod.parameters.all { param ->
                     !param.type.hasReferences(hierarchy)
                 }
             }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/ByteCodeLocations.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/ByteCodeLocations.kt
@@ -35,7 +35,7 @@ fun File.asByteCodeLocation(runtimeVersion: JavaVersion, isRuntime: Boolean = fa
     throw IllegalArgumentException("file $absolutePath is not jar-file nor build dir folder")
 }
 
-fun List<File>.filterExisted(): List<File> = filter { file ->
+fun List<File>.filterExisting(): List<File> = filter { file ->
     file.exists().also {
         if (!it) {
             logger.warn("${file.absolutePath} doesn't exists. make sure there is no mistake")

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/types/signature/JvmTypeKMetadataUpdateVisitor.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/types/signature/JvmTypeKMetadataUpdateVisitor.kt
@@ -18,9 +18,9 @@ package org.jacodb.impl.types.signature
 
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmTypeParameter
+import kotlinx.metadata.isNullable
 import org.jacodb.api.jvm.JvmType
 import org.jacodb.api.jvm.JvmTypeParameterDeclaration
-import org.jacodb.impl.bytecode.isNullable
 
 /**
  * Recursively visits type and take all info about nullability from given kmType

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/util/SequenceUtil.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/util/SequenceUtil.kt
@@ -1,0 +1,21 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jacodb.impl.util
+
+inline fun <T> Sequence(crossinline it: () -> Iterable<T>): Sequence<T> = object : Sequence<T> {
+    override fun iterator(): Iterator<T> = it().iterator()
+}

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/BaseInstructionsTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/BaseInstructionsTest.kt
@@ -25,7 +25,6 @@ import org.jacodb.api.jvm.ext.packageName
 import org.jacodb.impl.bytecode.JcDatabaseClassWriter
 import org.jacodb.impl.cfg.MethodNodeBuilder
 import org.jacodb.impl.features.hierarchyExt
-import org.jacodb.impl.fs.className
 import org.jacodb.testing.BaseTest
 import org.jacodb.testing.WithGlobalDB
 import org.junit.jupiter.api.Assertions
@@ -79,9 +78,10 @@ abstract class BaseInstructionsTest : BaseTest() {
                 .filter { it.enclosingClass == klass }
                 .map { method ->
                     if (method.isAbstract ||
-                        method.name.contains("$\$forInline")||
+                        method.name.contains("$\$forInline") ||
                         method.name.contains("lambda$") ||
-                        method.name.contains("stringConcat$")) {
+                        method.name.contains("stringConcat$")
+                    ) {
                         method.withAsmNode { it } // fixme: safe only in single-thread environment
                     } else {
                         try {

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/IRTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/cfg/IRTest.kt
@@ -346,7 +346,6 @@ abstract class IRTest : BaseInstructionsTest() {
     }
 
     @Test
-    @Disabled
     fun `get ir of jgit`() {
         runAlongLib(jgitLib)
     }

--- a/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/LibrariesMixin.kt
+++ b/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/LibrariesMixin.kt
@@ -76,7 +76,6 @@ private val classpath: List<String>
         val classpath = System.getProperty("java.class.path")
         return classpath.split(File.pathSeparatorChar)
             .filter { !it.contains("sootup") }
-            .toList()
     }
 
 


### PR DESCRIPTION
[jacodb-core] Minor: remove unnecessary .toList(), fix typo

[jacodb-core] Make Builders working correctly with same classes from different locations

[jacodb-core] Migrate to Kotlin 1.9.25 and kotlinx.metadata 0.9.0

[jacodb-core] RawInstListBuilder: less strict requirement of types compatibility

When copying locals for a new frame, consider argument of compatible type as a suitable variable. Types are compatible if they both are reference types, or both are primitive types of the same size (32 bits or 64 bits).

[jacodb-core] RawInstListBuilder: never copy argument of different type into new frame

[jacodb-core] RawInstListBuilder: never copy Kotlin's implicit argument "it" into new frame

Inline methods compiled with Kotlin can use single name ("it") for JcRawArguments having different types in different frames. So inheriting of such local from an outer frame can result in an invalid operation.

[jacodb-core] RawInstListBuilder: define two-pass calculation of try-catch handlers' predecessors

This commit changes the way how predecessors of try-catch blocks' handlers are calculated. In some specific cases, there can be several try-catch blocks with single handler. In that case, in order to get rid of the handler predecessors not belonging to all its try-catch blocks, we have to filter them in a separate pass though all try-cache blocks.

[jacodb-core] RawInstListBuilder: for try-catch handlers, use only outside the block predecessors

[jacodb-core] RawInstListBuilder: simplify calculation of predecessor frames for try-catch handlers

Get rid of traversing graph of instructions on calculation of predecessor frames for try-catch handlers. Instead, get correct predecessors of try-catch handlers (outside their blocks) in the buildGraph() method.

[jacodb-core] RawInstListBuilder: extract extension tryCatchBlocks() for a LabelNode

[jacodb-core] RawInstListBuilder: for try-catch handlers, use predecessors' frames outside the block

For a try-catch handler, we should not take predecessor frames from try-catch block itself, but we should try to find suitable predecessor frames outside the block.

[jacodb-core] RawInstListBuilder: correct suitable predecessors' frames for TryCatchBlockNodes handlers

Generally, any instruction in a TryCatchBlockNodes handler can use locals declared outside the block. However, prior to this commit, all predecessors of the handler were instructions from the block only. So for a TryCatchBlockNode handler, we should calculate suitable predecessor frames installed outside the block in addition to those calculated by predecessors from the block.

[jacodb-core] RawInstListBuilder: minor optimization of building CFG for TryCatchBlockNodes

[jacodb-core] RawInstListBuilder: get rid of "dead" instructions, update graph correspondingly

There are no longer frames not connected to the man CFG, so we no longer have a need in "dead instructions". Each instruction has a non-empty list of predecessors.

[jacodb-core] RawInstListBuilder: handle correctly stacks of "dead" frames

There can be some frames not connected to the man CFG. As of now, they are processed correctly - without errors and exceptions. But TODO: completely remove their instructions from instruction list.

[jacodb-core] RawInstListBuilder: never override later stack assignments

This change is similar to that for later assignments. It would probably fix some unknown bugs.

[build] Use ASM 9.6

[jacodb-core] RawInstListBuilder: on building frame, avoid LabelNodes being put to dead instructions

For FrameNode, search for LabelNode not being put to dead instructions and use this node for getting block predecessors.

[jacodb-core] RawInstListBuilder: never override later assignments

For JumpInsnNode, there can be several unknown frames at a time. In that case, later assignments for variables of some frame could clear those for another. To address this, collect later oin a flat list, so that later assignments would never be cleared.

[jacodb-core] RawInstListBuilder: simplify isBetween()

[jacodb-core] RawInstListBuilder: for non-static method, always make sure that first local variable is `JcRawThis`

[jacodb-core] Refactor copyLocals() in order to make it more readable and debuggable

[jacodb-core] In InMemoryHierarchy.syncQuery(), return lazily built sequence

[jacodb-core] In HierarchyExtensionERS.explicitSubClasses(), return lazily built sequence

[jacodb-core] In HierarchyExtensionSQL, do not use JCDBContext lazily in BatchedSequence lambda