### PR TITLE
Add `equals` for `EtsClassImpl`

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/EtsClass.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/EtsClass.kt
@@ -41,4 +41,17 @@ class EtsClassImpl(
     override fun toString(): String {
         return signature.toString()
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as EtsClassImpl
+
+        return signature == other.signature
+    }
+
+    override fun hashCode(): Int {
+        return signature.hashCode()
+    }
 }


### PR DESCRIPTION
This PR adds `equals` (and `hashCode`) impl for `EtsClassImpl`: two classes are considered to be equals iff their signatures are equal.