### PR TITLE
Fix unknown classes and ERS API improvement

### DIFF
--- a/jacodb-api-jvm/src/main/kotlin/org/jacodb/api/jvm/storage/ers/EntityIterable.kt
+++ b/jacodb-api-jvm/src/main/kotlin/org/jacodb/api/jvm/storage/ers/EntityIterable.kt
@@ -16,29 +16,29 @@
 
 package org.jacodb.api.jvm.storage.ers
 
-interface EntityIterable : Iterable<Entity> {
+interface EntityIterable : Sequence<Entity> {
 
-    val size: Long
+    val size: Long get() = toEntityIdSet().size.toLong()
 
-    val isEmpty: Boolean
+    val isEmpty: Boolean get() = size == 0L
 
     val isNotEmpty: Boolean get() = !isEmpty
 
-    operator fun contains(e: Entity): Boolean
+    operator fun contains(e: Entity): Boolean = toEntityIdSet().contains(e.id)
 
     operator fun plus(other: EntityIterable): EntityIterable = when (other) {
         EMPTY -> this
-        else -> CollectionEntityIterable(union(other))
+        else -> this.union(other)
     }
 
     operator fun times(other: EntityIterable): EntityIterable = when (other) {
         EMPTY -> EMPTY
-        else -> CollectionEntityIterable(intersect(other))
+        else -> this.intersect(other)
     }
 
-    operator fun minus(other: EntityIterable): EntityIterable = when(other) {
+    operator fun minus(other: EntityIterable): EntityIterable = when (other) {
         EMPTY -> this
-        else -> CollectionEntityIterable(subtract(other))
+        else -> this.subtract(other)
     }
 
     fun deleteAll() = forEach { entity -> entity.delete() }
@@ -48,8 +48,6 @@ interface EntityIterable : Iterable<Entity> {
         val EMPTY: EntityIterable = object : EntityIterable {
 
             override val size = 0L
-
-            override val isEmpty = true
 
             override fun contains(e: Entity) = false
 
@@ -64,15 +62,15 @@ interface EntityIterable : Iterable<Entity> {
     }
 }
 
-class CollectionEntityIterable(private val set: Collection<Entity>) : EntityIterable {
+class CollectionEntityIterable(private val c: Collection<Entity>) : EntityIterable {
 
-    override val size = set.size.toLong()
+    override val size = c.size.toLong()
 
-    override val isEmpty = set.isEmpty()
+    override val isEmpty = c.isEmpty()
 
-    override fun contains(e: Entity) = e in set
+    override fun contains(e: Entity) = e in c
 
-    override fun iterator() = set.iterator()
+    override fun iterator() = c.iterator()
 }
 
 class EntityIdCollectionEntityIterable(

--- a/jacodb-api-jvm/src/main/kotlin/org/jacodb/api/jvm/storage/ers/EntityIterableEx.kt
+++ b/jacodb-api-jvm/src/main/kotlin/org/jacodb/api/jvm/storage/ers/EntityIterableEx.kt
@@ -1,0 +1,107 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jacodb.api.jvm.storage.ers
+
+/**
+ * Default lazy implementations of binary operations over instances of `EntityIterable`
+ */
+fun EntityIterable.union(other: EntityIterable): EntityIterable {
+    val self = this
+    return object : EntityIterable {
+        override fun iterator(): Iterator<Entity> {
+            return object : Iterator<Entity> {
+
+                val iterated = HashSet<Entity>()
+                var iter = self.iterator()
+                var switchedToOther = false
+                var next: Entity? = null
+
+                override fun hasNext(): Boolean {
+                    advance()
+                    return next != null
+                }
+
+                override fun next(): Entity {
+                    advance()
+                    return (next ?: error("No more entities available")).also { next = null }
+                }
+
+                private fun advance() {
+                    if (next == null) {
+                        if (!switchedToOther) {
+                            if (iter.hasNext()) {
+                                next = iter.next().also {
+                                    iterated.add(it)
+                                }
+                                return
+                            }
+                            iter = other.iterator()
+                            switchedToOther = true
+                        }
+                        while (iter.hasNext()) {
+                            iter.next().let {
+                                if (it !in iterated) {
+                                    next = it
+                                    return
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fun EntityIterable.intersect(other: EntityIterable): EntityIterable {
+    val self = this
+    return object : EntityIterable {
+        override fun iterator(): Iterator<Entity> {
+            val otherSet = other.toEntityIdSet()
+            return self.filter { it.id in otherSet }.iterator()
+        }
+
+    }
+}
+
+fun EntityIterable.subtract(other: EntityIterable): EntityIterable {
+    val self = this
+    return object : EntityIterable {
+        override fun iterator(): Iterator<Entity> {
+            val otherSet = other.toEntityIdSet()
+            return self.filter { it.id !in otherSet }.iterator()
+        }
+
+    }
+}
+
+fun EntityIterable.toEntityIdSet(): Set<EntityId> {
+    val it = iterator()
+    if (!it.hasNext()) {
+        return emptySet()
+    }
+    val element = it.next()
+    if (!it.hasNext()) {
+        return setOf(element.id)
+    }
+    val result = LinkedHashSet<EntityId>()
+    result.add(element.id)
+    while (it.hasNext()) {
+        result.add(it.next().id)
+    }
+    return result
+}

--- a/jacodb-api-jvm/src/main/kotlin/org/jacodb/api/jvm/storage/ers/Transaction.kt
+++ b/jacodb-api-jvm/src/main/kotlin/org/jacodb/api/jvm/storage/ers/Transaction.kt
@@ -45,6 +45,21 @@ interface Transaction : Closeable {
      */
     fun getTypeId(type: String): Int
 
+    /**
+     * Returns set of property names ever being set to an entity of specified `type`.
+     */
+    fun getPropertyNames(type: String): Set<String> = emptySet()
+
+    /**
+     * Returns set of blob names ever being set to an entity of specified `type`.
+     */
+    fun getBlobNamesNames(type: String): Set<String> = emptySet()
+
+    /**
+     * Returns set of link names ever being set to an entity of specified `type`.
+     */
+    fun getLinkNamesNames(type: String): Set<String> = emptySet()
+
     fun all(type: String): EntityIterable
 
     fun <T : Any> find(type: String, propertyName: String, value: T): EntityIterable

--- a/jacodb-api-jvm/src/main/kotlin/org/jacodb/api/jvm/storage/kv/PluggableKeyValueStorage.kt
+++ b/jacodb-api-jvm/src/main/kotlin/org/jacodb/api/jvm/storage/kv/PluggableKeyValueStorage.kt
@@ -38,7 +38,7 @@ abstract class PluggableKeyValueStorage : Closeable {
 
     fun delete(map: String, key: ByteArray) = transactional { txn -> txn.delete(map, key) }
 
-    fun mapSize(map: String): Long = transactional { txn -> txn.getNamedMap(map).size(txn) }
+    fun mapSize(map: String): Long = transactional { txn -> txn.getNamedMap(map, create = false)?.size(txn) } ?: 0L
 
     fun all(map: String): List<Pair<ByteArray, ByteArray>> = readonlyTransactional { txn ->
         buildList {

--- a/jacodb-approximations/src/main/kotlin/org/jacodb/approximation/Approximations.kt
+++ b/jacodb-approximations/src/main/kotlin/org/jacodb/approximation/Approximations.kt
@@ -93,11 +93,11 @@ object Approximations : JcFeature<Any?, Any?>, JcClassExtFeature, JcInstExtFeatu
                     },
                     noSqlAction = { txn ->
                         val valueId = persistence.findSymbolId("value")
-                        txn.find("Annotation", "nameId", approxSymbol.compressed).asSequence()
+                        txn.find("Annotation", "nameId", approxSymbol.compressed)
                             .filter { it.getCompressedBlob<Int>("refKind") == RefKind.CLASS.ordinal }
                             .flatMap { annotation ->
                                 annotation.getLink("ref").let { clazz ->
-                                    annotation.getLinks("values").asSequence().map { clazz to it }
+                                    annotation.getLinks("values").map { clazz to it }
                                 }
                             }.filter { (_, annotationValue) ->
                                 valueId == annotationValue["nameId"]

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/JCDBSymbolsInternerImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/JCDBSymbolsInternerImpl.kt
@@ -121,7 +121,7 @@ class JCDBSymbolsInternerImpl : JCDBSymbolsInterner, Closeable {
                     val unwrapped = txn.unwrap
                     if (unwrapped is KVErsTransaction) {
                         val kvTxn = unwrapped.kvTxn
-                        val symbolsMap = kvTxn.getNamedMap(symbolsMapName)
+                        val symbolsMap = kvTxn.getNamedMap(symbolsMapName, create = true)!!
                         val stringBinding = BuiltInBindingProvider.getBinding(String::class.java)
                         val longBinding = BuiltInBindingProvider.getBinding(Long::class.java)
                         entries.forEach { (name, id) ->

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/JcSettings.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/JcSettings.kt
@@ -25,6 +25,7 @@ import org.jacodb.api.jvm.JcPersistenceImplSettings
 import org.jacodb.api.jvm.JcPersistenceSettings
 import org.jacodb.api.jvm.storage.ers.EmptyErsSettings
 import org.jacodb.api.jvm.storage.ers.ErsSettings
+import org.jacodb.impl.caches.guava.GUAVA_CACHE_PROVIDER_ID
 import org.jacodb.impl.storage.SQLITE_DATABASE_PERSISTENCE_SPI
 import org.jacodb.impl.storage.ers.ERS_DATABASE_PERSISTENCE_SPI
 import org.jacodb.impl.storage.ers.kv.KV_ERS_SPI
@@ -187,8 +188,8 @@ data class JcCacheSegmentSettings(
 
 enum class ValueStoreType { WEAK, SOFT, STRONG }
 
-
 class JcCacheSettings {
+    var cacheSpiId: String = GUAVA_CACHE_PROVIDER_ID
     var classes: JcCacheSegmentSettings = JcCacheSegmentSettings()
     var types: JcCacheSegmentSettings = JcCacheSegmentSettings()
     var rawInstLists: JcCacheSegmentSettings = JcCacheSegmentSettings()
@@ -223,7 +224,6 @@ class JcCacheSettings {
             flowGraphs =
                 JcCacheSegmentSettings(maxSize = maxSize, expiration = expiration, valueStoreType = valueStoreType)
         }
-
 }
 
 object JcSQLitePersistenceSettings : JcPersistenceImplSettings {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/features/Usages.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/features/Usages.kt
@@ -254,7 +254,7 @@ object Usages : JcFeature<UsageFeatureRequest, UsageFeatureResponse> {
                 noSqlAction = { txn ->
                     val classNameIds =
                         classNames.mapTo(mutableSetOf()) { className -> className.asSymbolId(symbolInterner) }
-                    txn.find("Callee", "calleeNameId", name.asSymbolId(symbolInterner).compressed).asSequence()
+                    txn.find("Callee", "calleeNameId", name.asSymbolId(symbolInterner).compressed)
                         .filter { callee ->
                             callee.getCompressedBlob<Long>("calleeClassId") in classNameIds &&
                                     callee.getCompressed<Long>("locationId")!! in locationIds &&

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/JcUnknownType.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/features/classpaths/JcUnknownType.kt
@@ -58,6 +58,15 @@ class JcUnknownType(
 
     override val access: Int
         get() = Opcodes.ACC_PUBLIC
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        return other is JcUnknownType && other.name == name
+    }
+
+    override fun hashCode(): Int = name.hashCode()
 }
 
 open class JcUnknownClassLookup(val clazz: JcClassOrInterface) : JcLookup<JcField, JcMethod> {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/AbstractJcDbPersistence.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/AbstractJcDbPersistence.kt
@@ -70,7 +70,7 @@ abstract class AbstractJcDbPersistence(
                     noSqlAction = { txn ->
                         txn.all(BytecodeLocationEntity.BYTECODE_LOCATION_ENTITY_TYPE).map {
                             PersistentByteCodeLocationData.fromErsEntity(it)
-                        }
+                        }.toList()
                     }
                 ).mapNotNull {
                     try {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/PersistentLocationsRegistry.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/PersistentLocationsRegistry.kt
@@ -82,7 +82,7 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
                             jcdb,
                             PersistentByteCodeLocationData.fromErsEntity(entity)
                         )
-                    }
+                    }.toList()
                 }
             )
         }
@@ -108,7 +108,7 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
                             jcdb,
                             PersistentByteCodeLocationData.fromErsEntity(entity)
                         )
-                    }
+                    }.toList()
                 }
             )
         }
@@ -142,7 +142,8 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
             context.execute(
                 sqlAction = { jooq ->
                     jooq.update(BYTECODELOCATIONS)
-                        .set(BYTECODELOCATIONS.STATE, LocationState.PROCESSED.ordinal).where(BYTECODELOCATIONS.ID.`in`(ids))
+                        .set(BYTECODELOCATIONS.STATE, LocationState.PROCESSED.ordinal)
+                        .where(BYTECODELOCATIONS.ID.`in`(ids))
                         .execute()
                 },
                 noSqlAction = { txn ->
@@ -288,15 +289,15 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
                         noSqlAction = { txn ->
                             txn.getEntityOrNull(BytecodeLocationEntity.BYTECODE_LOCATION_ENTITY_TYPE, toUpdate.id)
                                 ?.let {
-                                it.addLink(
-                                    BytecodeLocationEntity.UPDATED_LINK,
-                                    txn.getEntityOrNull(
-                                        BytecodeLocationEntity.BYTECODE_LOCATION_ENTITY_TYPE,
-                                        refreshed.id
-                                    )!!
-                                )
-                                it[BytecodeLocationEntity.STATE] = LocationState.OUTDATED.ordinal
-                            }
+                                    it.addLink(
+                                        BytecodeLocationEntity.UPDATED_LINK,
+                                        txn.getEntityOrNull(
+                                            BytecodeLocationEntity.BYTECODE_LOCATION_ENTITY_TYPE,
+                                            refreshed.id
+                                        )!!
+                                    )
+                                    it[BytecodeLocationEntity.STATE] = LocationState.OUTDATED.ordinal
+                                }
                         }
                     )
                 }
@@ -323,7 +324,7 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
                 noSqlAction = { txn ->
                     txn.all(BytecodeLocationEntity.BYTECODE_LOCATION_ENTITY_TYPE)
                         .filter { it.getLinks(BytecodeLocationEntity.UPDATED_LINK).isNotEmpty }
-                        .map { PersistentByteCodeLocationData.fromErsEntity(it) }
+                        .map { PersistentByteCodeLocationData.fromErsEntity(it) }.toList()
                 }
             )
                 .filterNot { data -> snapshots.any { it.ids.contains(data.id) } }
@@ -383,8 +384,9 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
                     value = path
                 )
                     .firstOrNull { it.get<String>(BytecodeLocationEntity.FILE_SYSTEM_ID) == fileSystemId }
-                    ?.let { PersistentByteCodeLocationData.fromErsEntity(it)
-                }
+                    ?.let {
+                        PersistentByteCodeLocationData.fromErsEntity(it)
+                    }
             }
         )
     }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ErsPersistenceImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ErsPersistenceImpl.kt
@@ -224,7 +224,7 @@ class ErsPersistenceImpl(
         return read { context ->
             context.txn.find("Class", "locationId", location.id.compressed).map {
                 it.toClassSource(db, findSymbolName(it.getCompressed<Long>("nameId") ?: throw NullPointerException()))
-            }
+            }.toList()
         }
     }
 
@@ -245,7 +245,7 @@ class ErsPersistenceImpl(
     private fun findClassSourcesImpl(context: JCDBContext, cp: JcClasspath, fullName: String): Sequence<ClassSource> {
         val ids = cp.registeredLocationIds
         return context.txn.find("Class", "nameId", findSymbolId(fullName).compressed)
-            .asSequence().filter { it.getCompressed<Long>("locationId") in ids }
+            .filter { it.getCompressed<Long>("locationId") in ids }
             .map { it.toClassSource(cp.db, fullName) }
     }
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/decorators/AbstractDecorators.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/decorators/AbstractDecorators.kt
@@ -35,6 +35,9 @@ abstract class AbstractTransactionDecorator : Transaction {
     override fun getEntityOrNull(id: EntityId): Entity? = delegate.getEntityOrNull(id)
     override fun deleteEntity(id: EntityId) = delegate.deleteEntity(id)
     override fun getTypeId(type: String): Int = delegate.getTypeId(type)
+    override fun getPropertyNames(type: String): Set<String> = delegate.getPropertyNames(type)
+    override fun getBlobNamesNames(type: String): Set<String> = delegate.getBlobNamesNames(type)
+    override fun getLinkNamesNames(type: String): Set<String> = delegate.getLinkNamesNames(type)
     override fun all(type: String): EntityIterable = delegate.all(type)
     override fun <T : Any> find(type: String, propertyName: String, value: T): EntityIterable =
         delegate.find(type, propertyName, value)

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/kv/KVEntityRelationshipStorage.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/kv/KVEntityRelationshipStorage.kt
@@ -20,7 +20,6 @@ import org.jacodb.api.jvm.storage.ers.Binding
 import org.jacodb.api.jvm.storage.ers.ERSConflictingTransactionException
 import org.jacodb.api.jvm.storage.ers.EntityRelationshipStorage
 import org.jacodb.api.jvm.storage.ers.Transaction
-import org.jacodb.api.jvm.storage.kv.EmptyNamedMap
 import org.jacodb.api.jvm.storage.kv.NamedMap
 import org.jacodb.api.jvm.storage.kv.PluggableKeyValueStorage
 import org.jacodb.impl.storage.ers.decorators.withAllDecorators
@@ -85,7 +84,8 @@ class KVEntityRelationshipStorage(private val kvStorage: PluggableKeyValueStorag
         kvTxn: org.jacodb.api.jvm.storage.kv.Transaction
     ): Int? {
         entityTypes[type]?.let { return it }
-        return kvTxn.get(entityTypesMap(kvTxn), stringBinding.getBytes(type))?.let { typeIdEntry ->
+        val entityTypesMap = entityTypesMap(kvTxn, create = false) ?: return null
+        return kvTxn.get(entityTypesMap, stringBinding.getBytes(type))?.let { typeIdEntry ->
             intBinding.getObjectCompressed(typeIdEntry).also { entityTypes[type] = it }
         }
     }
@@ -96,38 +96,37 @@ class KVEntityRelationshipStorage(private val kvStorage: PluggableKeyValueStorag
     ): Int {
         return entityTypes.computeIfAbsent(type) {
             val typeEntry = stringBinding.getBytes(type)
-            kvTxn.get(entityTypesMap(kvTxn), typeEntry)?.let { typeIdEntry ->
+            val entityTypesMap = entityTypesMap(kvTxn, create = true)!!
+            kvTxn.get(entityTypesMap, typeEntry)?.let { typeIdEntry ->
                 intBinding.getObjectCompressed(typeIdEntry)
             } ?: run {
-                entityTypesMap(kvTxn).size(kvTxn).toInt().also { typeId ->
-                    kvTxn.put(entityTypesMap(kvTxn), typeEntry, intBinding.getBytesCompressed(typeId))
+                entityTypesMap.size(kvTxn).toInt().also { typeId ->
+                    kvTxn.put(entityTypesMap, typeEntry, intBinding.getBytesCompressed(typeId))
                 }
             }
         }
     }
 
-    private fun entityTypesMap(txn: org.jacodb.api.jvm.storage.kv.Transaction): NamedMap {
-        return entityTypesMap ?: txn.getNamedMap(entityTypesMapName).also {
-            if (it !== EmptyNamedMap) {
-                entityTypesMap = it
-            }
+    private fun entityTypesMap(txn: org.jacodb.api.jvm.storage.kv.Transaction, create: Boolean): NamedMap? {
+        return entityTypesMap ?: txn.getNamedMap(entityTypesMapName, create)?.also {
+            entityTypesMap = it
         }
     }
 
-    internal fun entityCountersMap(txn: org.jacodb.api.jvm.storage.kv.Transaction): NamedMap {
-        return entityCountersMap ?: txn.getNamedMap(entityCountersMapName).also {
-            if (it !== EmptyNamedMap) {
-                entityCountersMap = it
-            }
+    internal fun entityCountersMap(txn: org.jacodb.api.jvm.storage.kv.Transaction, create: Boolean): NamedMap? {
+        return entityCountersMap ?: txn.getNamedMap(entityCountersMapName, create)?.also {
+            entityCountersMap = it
         }
     }
 
-    internal fun deletedEntitiesMap(typeId: Int, txn: org.jacodb.api.jvm.storage.kv.Transaction): NamedMap {
+    internal fun deletedEntitiesMap(
+        typeId: Int,
+        txn: org.jacodb.api.jvm.storage.kv.Transaction,
+        create: Boolean
+    ): NamedMap? {
         return deletedEntitiesMaps.getOrElse(typeId) {
-            txn.getNamedMap(deletedEntitiesMapName(typeId)).also {
-                if (it !== EmptyNamedMap) {
-                    deletedEntitiesMaps[typeId] = it
-                }
+            txn.getNamedMap(deletedEntitiesMapName(typeId), create)?.also {
+                deletedEntitiesMaps[typeId] = it
             }
         }
     }
@@ -135,47 +134,68 @@ class KVEntityRelationshipStorage(private val kvStorage: PluggableKeyValueStorag
     internal fun propertiesMap(
         typeId: Int,
         propName: String,
-        txn: org.jacodb.api.jvm.storage.kv.Transaction
-    ): NamedMap {
+        txn: org.jacodb.api.jvm.storage.kv.Transaction,
+        create: Boolean
+    ): NamedMap? {
         return propertiesMaps.getOrElse(typeId with propName) {
-            txn.getNamedMap(propertiesMapName(typeId, propName)).also {
-                if (it !== EmptyNamedMap) {
-                    propertiesMaps[typeId with propName] = it
-                }
+            txn.getNamedMap(propertiesMapName(typeId, propName), create)?.also {
+                propertiesMaps[typeId with propName] = it
             }
         }
     }
 
+    /**
+     * Returns property name and type id if specified map name is a properties map name for this property and type id.
+     */
+    internal fun getPropNameFromMapName(mapName: String): Pair<String, Int>? =
+        mapName.getPropertyNameFromMapName("#properties")
+
+    /**
+     * Returns blob name and type id if specified map name is a blobs map name for this blob and type id.
+     */
+    internal fun getBlobNameFromMapName(mapName: String): Pair<String, Int>? =
+        mapName.getPropertyNameFromMapName("#blobs")
+
+    /**
+     * Returns link name and type id if specified map name is a linkTargets map name for this link and type id.
+     */
+    internal fun getLinkNameFromMapName(mapName: String): Pair<String, Int>? =
+        mapName.getPropertyNameFromMapName("#link_targets$withDuplicates")
+
     internal fun propertiesIndex(
         typeId: Int,
         propName: String,
-        txn: org.jacodb.api.jvm.storage.kv.Transaction
-    ): NamedMap {
-        return propertiesIndices.getOrPut(typeId with propName) {
-            txn.getNamedMap(propertiesIndexName(typeId, propName))
+        txn: org.jacodb.api.jvm.storage.kv.Transaction,
+        create: Boolean
+    ): NamedMap? {
+        return propertiesIndices.getOrElse(typeId with propName) {
+            txn.getNamedMap(propertiesIndexName(typeId, propName), create)?.also {
+                propertiesIndices[typeId with propName] = it
+            }
         }
     }
 
     internal fun blobsMap(
         typeId: Int,
         blobName: String,
-        txn: org.jacodb.api.jvm.storage.kv.Transaction
-    ): NamedMap {
+        txn: org.jacodb.api.jvm.storage.kv.Transaction,
+        create: Boolean
+    ): NamedMap? {
         return blobsMaps.getOrElse(typeId with blobName) {
-            txn.getNamedMap(blobsMapName(typeId, blobName)).also {
-                if (it !== EmptyNamedMap) {
-                    blobsMaps[typeId with blobName] = it
-                }
+            txn.getNamedMap(blobsMapName(typeId, blobName), create)?.also {
+                blobsMaps[typeId with blobName] = it
             }
         }
     }
 
-    internal fun linkTargetTypesMap(typeId: Int, txn: org.jacodb.api.jvm.storage.kv.Transaction): NamedMap {
+    internal fun linkTargetTypesMap(
+        typeId: Int,
+        txn: org.jacodb.api.jvm.storage.kv.Transaction,
+        create: Boolean
+    ): NamedMap? {
         return linkTargetTypesMaps.getOrElse(typeId) {
-            txn.getNamedMap(linkTargetTypesMapName(typeId)).also {
-                if (it !== EmptyNamedMap) {
-                    linkTargetTypesMaps[typeId] = it
-                }
+            txn.getNamedMap(linkTargetTypesMapName(typeId), create)?.also {
+                linkTargetTypesMaps[typeId] = it
             }
         }
     }
@@ -183,10 +203,13 @@ class KVEntityRelationshipStorage(private val kvStorage: PluggableKeyValueStorag
     internal fun linkTargetsMap(
         typeId: Int,
         linkName: String,
-        txn: org.jacodb.api.jvm.storage.kv.Transaction
-    ): NamedMap {
-        return linkTargetsMaps.getOrPut(typeId with linkName) {
-            txn.getNamedMap(linkTargetsMapName(typeId, linkName))
+        txn: org.jacodb.api.jvm.storage.kv.Transaction,
+        create: Boolean
+    ): NamedMap? {
+        return linkTargetsMaps.getOrElse(typeId with linkName) {
+            txn.getNamedMap(linkTargetsMapName(typeId, linkName), create)?.also {
+                linkTargetsMaps[typeId with linkName] = it
+            }
         }
     }
 }
@@ -206,25 +229,36 @@ private val entityTypesMapName = "${packageNamePrefix}entities_types"
  */
 private val entityCountersMapName = "${packageNamePrefix}entity_counters"
 
-private fun deletedEntitiesMapName(typeId: Int) = "${packageNamePrefix}$typeId#deleted_entities"
+private fun deletedEntitiesMapName(typeId: Int) = "$packageNamePrefix$typeId#deleted_entities"
 
 /**
  * InstanceId (Long) -> prop value (ByteArray)
  */
-private fun propertiesMapName(typeId: Int, name: String) = "${packageNamePrefix}$typeId#$name#properties"
+private fun propertiesMapName(typeId: Int, name: String) = "$packageNamePrefix$typeId#$name#properties"
 
 /**
  * InstanceId (Long) -> prop value (ByteArray)
  */
 private fun propertiesIndexName(typeId: Int, name: String) =
-    "${packageNamePrefix}$typeId#$name#properties_idx$withDuplicates"
+    "$packageNamePrefix$typeId#$name#properties_idx$withDuplicates"
 
 /**
  * InstanceId (Long) -> prop value (ByteArray)
  */
-private fun blobsMapName(typeId: Int, name: String) = "${packageNamePrefix}$typeId#$name#blobs"
+private fun blobsMapName(typeId: Int, name: String) = "$packageNamePrefix$typeId#$name#blobs"
 
-private fun linkTargetTypesMapName(typeId: Int) = "${packageNamePrefix}$typeId#link_target_types"
+private fun linkTargetTypesMapName(typeId: Int) = "$packageNamePrefix$typeId#link_target_types"
 
 private fun linkTargetsMapName(typeId: Int, name: String) =
-    "${packageNamePrefix}$typeId#$name#link_targets$withDuplicates"
+    "$packageNamePrefix$typeId#$name#link_targets$withDuplicates"
+
+private fun String.getPropertyNameFromMapName(suffix: String): Pair<String, Int>? {
+    if (!startsWith(packageNamePrefix) || !endsWith(suffix)) {
+        return null
+    }
+    val typeAndName = substring(packageNamePrefix.length, indexOf(suffix)).split('#')
+    if (typeAndName.size != 2) {
+        error("Invalid structure of map name")
+    }
+    return typeAndName[1] to typeAndName[0].toInt()
+}

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ram/RAMTransaction.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ram/RAMTransaction.kt
@@ -49,6 +49,12 @@ internal class RAMTransaction(override val ers: RAMEntityRelationshipStorage) : 
 
     override fun getTypeId(type: String): Int = dataContainerChecked.getTypeId(type)
 
+    override fun getPropertyNames(type: String): Set<String> = dataContainerChecked.getPropertyNames(type)
+
+    override fun getBlobNamesNames(type: String): Set<String> = dataContainerChecked.getBlobNames(type)
+
+    override fun getLinkNamesNames(type: String): Set<String> = dataContainerChecked.getLinkNames(type)
+
     override fun all(type: String): EntityIterable = dataContainerChecked.all(this, type)
 
     override fun <T : Any> find(type: String, propertyName: String, value: T): EntityIterable {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ram/TransactionalPersistentMap.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ram/TransactionalPersistentMap.kt
@@ -30,6 +30,10 @@ internal class TransactionalPersistentMap<K, V>(private val committed: Persisten
         return committed[key]
     }
 
+    fun entries(): Iterable<Map.Entry<K, V>> {
+        return (mutated ?: committed).entries
+    }
+
     fun put(key: K, value: V) {
         mutated()[key] = value
     }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/kv/rocks/RocksKeyValueStorage.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/kv/rocks/RocksKeyValueStorage.kt
@@ -35,6 +35,7 @@ internal abstract class RocksKeyValueStorage : PluggableKeyValueStorage() {
 
     abstract fun getNamedMapOrNull(name: String): RocksNamedMap?
     abstract fun getOrCreateNamedMap(name: String): RocksNamedMap
+    abstract fun getMapNames(): Set<String>
 }
 
 internal class RocksKeyValueStorageImpl(location: String) : RocksKeyValueStorage() {
@@ -78,7 +79,7 @@ internal class RocksKeyValueStorageImpl(location: String) : RocksKeyValueStorage
                         sizesColumnFamily = getOrCreateColumnFamily(
                             "org.jacodb.impl.storage.kv.rocks.RocksKeyValueStorage.##column##family##sizes##"
                         )
-                    } catch(e: Throwable) {
+                    } catch (e: Throwable) {
                         columnFamilies.forEach { it.close() }
                         rocksDB.close()
                         throw e
@@ -152,6 +153,13 @@ internal class RocksKeyValueStorageImpl(location: String) : RocksKeyValueStorage
         return when {
             isMapWithKeyDuplicates?.invoke(name) == true -> DuplicateRocksNamedMap(columnFamilyHandle)
             else -> NoDuplicateRocksNamedMap(columnFamilyHandle)
+        }
+    }
+
+    override fun getMapNames(): Set<String> {
+        val stringBinding = BuiltInBindingProvider.getBinding(String::class.java)
+        return columnFamiliesMap.mapTo(sortedSetOf()) {
+            stringBinding.getObject(it.key.toByteArray())
         }
     }
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/kv/xodus/XodusEnvironmentsEx.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/kv/xodus/XodusEnvironmentsEx.kt
@@ -28,8 +28,12 @@ internal val ByteIterable.asByteArray: ByteArray
 
 internal fun environmentConfig(configurer: EnvironmentConfig.() -> Unit) = EnvironmentConfig().apply(configurer)
 
+fun <K : Any, V : Any> ObjectCacheBase<K, V>.getOrElse(key: K, retriever: (K) -> V): V {
+    return tryKey(key) ?: retriever(key)
+}
+
 fun <K : Any, V : Any> ObjectCacheBase<K, V>.getOrPut(key: K, retriever: (K) -> V): V {
-    return tryKey(key) ?: retriever(key).also { obj -> cacheObject(key, obj) }
+    return getOrElse(key, retriever).also { obj -> cacheObject(key, obj) }
 }
 
 fun <K : Any, V : Any> ObjectCacheBase<K, V>.getOrPutConcurrent(key: K, retriever: (K) -> V): V {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/kv/xodus/XodusTransaction.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/kv/xodus/XodusTransaction.kt
@@ -31,9 +31,11 @@ internal class XodusTransaction(
 
     override val isFinished: Boolean get() = xodusTxn.isFinished
 
-    override fun getNamedMap(name: String): NamedMap {
-        return XodusNamedMap(storage.getMap(xodusTxn, name))
+    override fun getNamedMap(name: String, create: Boolean): NamedMap? {
+        return storage.getMap(xodusTxn, name, create)?.let { XodusNamedMap(it) }
     }
+
+    override fun getMapNames(): Set<String> = storage.getMapNames(xodusTxn)
 
     override fun get(map: NamedMap, key: ByteArray): ByteArray? {
         map as XodusNamedMap

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/types/JcTypedFieldImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/types/JcTypedFieldImpl.kt
@@ -16,8 +16,13 @@
 
 package org.jacodb.impl.types
 
-import org.jacodb.api.jvm.*
+import org.jacodb.api.jvm.JcField
+import org.jacodb.api.jvm.JcRefType
+import org.jacodb.api.jvm.JcSubstitutor
+import org.jacodb.api.jvm.JcType
+import org.jacodb.api.jvm.JcTypedField
 import org.jacodb.api.jvm.ext.isNullable
+import org.jacodb.api.jvm.throwClassNotFound
 import org.jacodb.impl.bytecode.JcAnnotationImpl
 import org.jacodb.impl.bytecode.JcFieldImpl
 import org.jacodb.impl.types.signature.FieldResolutionImpl
@@ -57,4 +62,13 @@ class JcTypedFieldImpl(
         } ?: type
     }
 
+    // delegate identity to JcField
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+        return other is JcTypedFieldImpl && field == other.field
+    }
+
+    override fun hashCode(): Int = field.hashCode()
 }

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/UnknownClassesTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/UnknownClassesTest.kt
@@ -20,16 +20,21 @@ import org.jacodb.api.jvm.JcMethod
 import org.jacodb.api.jvm.ext.cfg.callExpr
 import org.jacodb.api.jvm.ext.cfg.fieldRef
 import org.jacodb.api.jvm.ext.findClass
+import org.jacodb.api.jvm.ext.findDeclaredMethodOrNull
+import org.jacodb.api.jvm.ext.findFieldOrNull
+import org.jacodb.api.jvm.ext.findMethodOrNull
+import org.jacodb.api.jvm.ext.objectClass
 import org.jacodb.impl.features.classpaths.JcUnknownClass
 import org.jacodb.impl.features.classpaths.UnknownClassMethodsAndFields
 import org.jacodb.impl.features.classpaths.UnknownClasses
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class UnknownClassesTest : BaseTest() {
 
-    companion object : WithGlobalDB(UnknownClasses, UnknownClassMethodsAndFields)
+    companion object : WithGlobalDB(UnknownClasses)
 
     @Test
     fun `unknown class is resolved`() {
@@ -74,6 +79,18 @@ class UnknownClassesTest : BaseTest() {
         )
         clazz.forEach {
             it.declaredMethods.forEach { it.assertCfg() }
+        }
+    }
+
+    @Test
+    fun `object doesn't have unknown methods and fields`() {
+        cp.objectClass.let { clazz ->
+            assertTrue(clazz !is JcUnknownClass)
+            assertTrue(clazz.declaredFields.isEmpty())
+            val xxxField = clazz.findFieldOrNull("xxx")
+            assertNull(xxxField)
+            val xxxMethod = clazz.findMethodOrNull("xxx", "(JILjava/lang/Exception;)V")
+            assertNull(xxxMethod)
         }
     }
 

--- a/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/storage/ers/EntityRelationshipStorageTest.kt
+++ b/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/storage/ers/EntityRelationshipStorageTest.kt
@@ -40,6 +40,7 @@ import org.jacodb.api.jvm.storage.ers.typed.newEntity
 import org.jacodb.api.jvm.storage.ers.typed.property
 import org.jacodb.impl.storage.ers.kv.KV_ERS_SPI
 import org.jacodb.impl.storage.ers.ram.RAM_ERS_SPI
+import org.jacodb.impl.storage.ers.sql.SQL_ERS_SPI
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -88,6 +89,15 @@ abstract class EntityRelationshipStorageTest {
         val noSuchProperty: String? by propertyOf(user)
         assertNull(noSuchProperty)
 
+        // TODO: resolve this
+        if (ersSpi.id != SQL_ERS_SPI) {
+            txn.getPropertyNames("User").toList().let { props ->
+                assertEquals(2, props.size)
+                assertEquals("login", props[0])
+                assertEquals("password", props[1])
+            }
+        }
+
         user.deleteProperty("login")
         val deletedLogin: String? by propertyOf(user, "login")
         assertNull(deletedLogin)
@@ -110,6 +120,16 @@ abstract class EntityRelationshipStorageTest {
             user["seed"] = 2808.compressed
             user["login"] = "user2"
         }
+
+        // TODO: resolve this
+        if (ersSpi.id != SQL_ERS_SPI) {
+            txn.getPropertyNames("User").toList().let { props ->
+                assertEquals(2, props.size)
+                assertEquals("login", props[0])
+                assertEquals("seed", props[1])
+            }
+        }
+
         val found = txn.find("User", "seed", 2808.compressed)
         assertFalse(found.isEmpty)
         assertEquals(2L, found.size)


### PR DESCRIPTION
[jacodb-core] Specify identity for UnknownField, UnknownMethod, JcTypedFieldImpl

[jacodb-core] Fix operations with map names in LmdbKeyValueStorage

[jacodb-core] Avoid creation of named maps for R/O operations

[jacodb-core] Force use of sortedSet by getMapNames()

[jacodb-core] For an entity type, add ability to get names of used properties/blobs/links

The sets of names of properties/blobs/links returned by the API consist of names ever have been set to an entity of specified type. So the sets can contain names of properties/blobs/links that could actually have been deleted in all entities of specified type.

As a bonus, the way how named map are created was changed. As of now, any R/O operation doesn't implicitly create name map, whereas R/W operation does.

TODO: fix implementation atop of LMDB and SQLite.

[jacodb-core] Define equals()/hashcode() in JcUnknownClass & JcUnknownType

[jacodb-core] Apply JcUnknownClassLookup only for instances of JcUnknownClass

As of now, there is no longer an ability to get and unknown field or an unknown method for instances other than JcUnknownClass.

[jacodb-api] ERS API: inherit EntityIterable from Kotlin Sequence

As of now, EntityIterable is no longer Iterable, but Kotlin Sequence. All methods and properties, except iterator(), have default implementations. Binary operations are implemented as lazy sequences.