### PR TITLE
Features performance fixes

### DIFF
--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/JcClasspathImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/JcClasspathImpl.kt
@@ -46,6 +46,7 @@ import org.jacodb.impl.features.classpaths.AbstractJcResolvedResult.JcResolvedCl
 import org.jacodb.impl.features.classpaths.AbstractJcResolvedResult.JcResolvedTypeResultImpl
 import org.jacodb.impl.features.classpaths.ClasspathCache
 import org.jacodb.impl.features.classpaths.JcUnknownClass
+import org.jacodb.impl.features.classpaths.UnknownClassMethodsAndFields
 import org.jacodb.impl.features.classpaths.UnknownClasses
 import org.jacodb.impl.features.classpaths.isResolveAllToUnknown
 import org.jacodb.impl.fs.ClassSourceImpl
@@ -71,7 +72,9 @@ class JcClasspathImpl(
         if (!features.any { it is UnknownClasses }) {
             features + JcClasspathFeatureImpl()
         } else {
-            features.filter { it !is UnknownClasses } + JcClasspathFeatureImpl() + UnknownClasses
+            (features.filter { it !is UnknownClasses } + JcClasspathFeatureImpl() + UnknownClasses).let {
+                it.filter { it !is UnknownClassMethodsAndFields } + UnknownClassMethodsAndFields
+            }
         })
 
     override suspend fun refreshed(closeOld: Boolean): JcClasspath {

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/storage/ers/CompactPersistentLongSetTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/storage/ers/CompactPersistentLongSetTest.kt
@@ -18,6 +18,7 @@ package org.jacodb.testing.storage.ers
 
 import org.jacodb.impl.storage.ers.ram.CompactPersistentLongSet
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class CompactPersistentLongSetTest {
@@ -36,5 +37,7 @@ class CompactPersistentLongSetTest {
         set = set.remove(3L)
         assertEquals(set.size, 1)
         assertEquals(setOf(1L), set.toSet())
+        set = set.remove(1L)
+        assertTrue(set.isEmpty())
     }
 }


### PR DESCRIPTION
[jacodb-core] Add more optimizations of memory usage by CompactPersistentLongSet

For sets of size 2, special pair of longs added to avoid boxing. Longs are interned if possible. Elements of PackedPersistentLongSet are interned if possible.

[jacodb-core] Use array of features to iterate over them in FeaturesChain

[jacodb-core] Make sure UnknownClassMethodsAndFields is after UnknownClasses in featuresChain