### PR TITLE
Fix maven publish issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -203,6 +203,13 @@ if (!repoUrl.isNullOrEmpty()) {
             publications {
                 register<MavenPublication>("jar") {
                     from(components["java"])
+                    setOf("apiElements", "runtimeElements")
+                        .flatMap { configName -> configurations[configName].hierarchy }
+                        .forEach { configuration ->
+                            configuration.dependencies.removeIf { dependency ->
+                                dependency.version.isNullOrBlank()
+                            }
+                        }
                     artifact(tasks.named("sourcesJar"))
                     artifact(tasks.named("dokkaJavadocJar"))
 

--- a/jacodb-api-jvm/build.gradle.kts
+++ b/jacodb-api-jvm/build.gradle.kts
@@ -7,7 +7,6 @@ dependencies {
     api(Libs.asm_commons)
     api(Libs.asm_util)
 
-    api(Libs.kotlinx_collections_immutable)
     api(Libs.kotlinx_coroutines_core)
     api(Libs.kotlinx_coroutines_jdk8)
 


### PR DESCRIPTION
[build] Publish from(components["java"])

[build] Fix maven publishing
- avoid publishing of test-fixtures jars;
- avoid dependencies with no version set.

[build] Remove unnecessary explicit dependency of jacodb-api-jvm on Libs.kotlinx_collections_immutable