### PR TITLE
Add Raw Stmt/Value/Type

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val kotlinx_collections_immutable = "0.3.5"
     const val kotlinx_coroutines = "1.6.4"
     const val kotlin_metadata = kotlin
-    const val kotlinx_serialization = "1.4.1"
+    const val kotlinx_serialization = "1.8.0"
     const val licenser = "0.6.1"
     const val mockk = "1.13.3"
     const val sarif4k = "0.5.0"

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/base/EtsEntity.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/base/EtsEntity.kt
@@ -28,6 +28,13 @@ interface EtsEntity : CommonExpr {
         EtsValue.Visitor<R>,
         EtsExpr.Visitor<R> {
 
+        fun visit(value: EtsRawEntity): R {
+            if (this is Default) {
+                return defaultVisit(value)
+            }
+            error("Cannot handle ${value::class.java.simpleName}: $value")
+        }
+
         interface Default<out R> : Visitor<R>,
             EtsValue.Visitor.Default<R>,
             EtsExpr.Visitor.Default<R> {
@@ -40,4 +47,18 @@ interface EtsEntity : CommonExpr {
     }
 
     fun <R> accept(visitor: Visitor<R>): R
+}
+
+data class EtsRawEntity(
+    val kind: String,
+    val extra: Map<String, Any> = emptyMap(),
+    override val type: EtsType,
+) : EtsEntity {
+    override fun toString(): String {
+        return "$kind $extra: $type"
+    }
+
+    override fun <R> accept(visitor: EtsEntity.Visitor<R>): R {
+        return visitor.visit(this)
+    }
 }

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/base/EtsRef.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/base/EtsRef.kt
@@ -45,47 +45,47 @@ data class EtsParameterRef(
     }
 }
 
-data class EtsCaughtExceptionRef(
-    override val type: EtsType,
-) : EtsValue {
-    override fun toString(): String {
-        return "catch($type)"
-    }
-
-    override fun <R> accept(visitor: EtsValue.Visitor<R>): R {
-        return visitor.visit(this)
-    }
-}
-
-data class EtsGlobalRef(
-    val name: String,
-    val ref: EtsValue?, // TODO: check whether it could be EtsEntity at best
-) : EtsValue {
-    override val type: EtsType
-        get() = ref?.type ?: EtsUnknownType
-
-    override fun toString(): String {
-        return "global $name"
-    }
-
-    override fun <R> accept(visitor: EtsValue.Visitor<R>): R {
-        return visitor.visit(this)
-    }
-}
-
-data class EtsClosureFieldRef(
-    val base: EtsLocal,
-    val fieldName: String,
-    override val type: EtsType,
-) : EtsValue {
-    override fun toString(): String {
-        return "$base.$fieldName"
-    }
-
-    override fun <R> accept(visitor: EtsValue.Visitor<R>): R {
-        return visitor.visit(this)
-    }
-}
+// data class EtsCaughtExceptionRef(
+//     override val type: EtsType,
+// ) : EtsValue {
+//     override fun toString(): String {
+//         return "catch($type)"
+//     }
+//
+//     override fun <R> accept(visitor: EtsValue.Visitor<R>): R {
+//         return visitor.visit(this)
+//     }
+// }
+//
+// data class EtsGlobalRef(
+//     val name: String,
+//     val ref: EtsValue?, // TODO: check whether it could be EtsEntity at best
+// ) : EtsValue {
+//     override val type: EtsType
+//         get() = ref?.type ?: EtsUnknownType
+//
+//     override fun toString(): String {
+//         return "global $name"
+//     }
+//
+//     override fun <R> accept(visitor: EtsValue.Visitor<R>): R {
+//         return visitor.visit(this)
+//     }
+// }
+//
+// data class EtsClosureFieldRef(
+//     val base: EtsLocal,
+//     val fieldName: String,
+//     override val type: EtsType,
+// ) : EtsValue {
+//     override fun toString(): String {
+//         return "$base.$fieldName"
+//     }
+//
+//     override fun <R> accept(visitor: EtsValue.Visitor<R>): R {
+//         return visitor.visit(this)
+//     }
+// }
 
 data class EtsArrayAccess(
     val array: EtsValue,

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/base/EtsValue.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/base/EtsValue.kt
@@ -32,9 +32,6 @@ interface EtsValue : EtsEntity, CommonValue {
         // Ref
         fun visit(value: EtsThis): R
         fun visit(value: EtsParameterRef): R
-        fun visit(value: EtsCaughtExceptionRef): R
-        fun visit(value: EtsGlobalRef): R
-        fun visit(value: EtsClosureFieldRef): R
         fun visit(value: EtsArrayAccess): R
         fun visit(value: EtsInstanceFieldRef): R
         fun visit(value: EtsStaticFieldRef): R
@@ -50,9 +47,6 @@ interface EtsValue : EtsEntity, CommonValue {
 
             override fun visit(value: EtsThis): R = defaultVisit(value)
             override fun visit(value: EtsParameterRef): R = defaultVisit(value)
-            override fun visit(value: EtsCaughtExceptionRef): R = defaultVisit(value)
-            override fun visit(value: EtsGlobalRef): R = defaultVisit(value)
-            override fun visit(value: EtsClosureFieldRef): R = defaultVisit(value)
             override fun visit(value: EtsArrayAccess): R = defaultVisit(value)
             override fun visit(value: EtsInstanceFieldRef): R = defaultVisit(value)
             override fun visit(value: EtsStaticFieldRef): R = defaultVisit(value)

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Model.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Model.kt
@@ -19,7 +19,6 @@ package org.jacodb.ets.dto
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import java.io.InputStream
@@ -33,13 +32,17 @@ data class EtsFileDto(
     val exportInfos: List<ExportInfoDto>,
 ) {
     companion object {
+        private val json = Json {
+            serializersModule = dtoModule
+        }
+
         fun loadFromJson(jsonString: String): EtsFileDto {
-            return Json.decodeFromString(jsonString)
+            return json.decodeFromString(jsonString)
         }
 
         @OptIn(ExperimentalSerializationApi::class)
         fun loadFromJson(stream: InputStream): EtsFileDto {
-            return Json.decodeFromStream(stream)
+            return json.decodeFromStream(stream)
         }
     }
 }

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Signatures.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Signatures.kt
@@ -16,89 +16,53 @@
 
 package org.jacodb.ets.dto
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class FileSignatureDto(
     val projectName: String,
     val fileName: String,
-) {
-    override fun toString(): String {
-        return "@$projectName/$fileName"
-    }
-}
+)
 
 @Serializable
 data class NamespaceSignatureDto(
     val name: String,
     val declaringFile: FileSignatureDto,
     val declaringNamespace: NamespaceSignatureDto? = null,
-) {
-    override fun toString(): String {
-        return if (declaringNamespace != null) {
-            "$declaringNamespace::$name"
-        } else {
-            "$declaringFile::$name"
-        }
-    }
-}
-
+)
 @Serializable
 data class ClassSignatureDto(
     val name: String,
     val declaringFile: FileSignatureDto,
     val declaringNamespace: NamespaceSignatureDto? = null,
-) {
-    override fun toString(): String {
-        return if (declaringNamespace != null) {
-            "$declaringNamespace::$name"
-        } else {
-            "$declaringFile::$name"
-        }
-    }
-}
+)
 
 @Serializable
 data class FieldSignatureDto(
     val declaringClass: ClassSignatureDto,
     val name: String,
     val type: TypeDto,
-) {
-    override fun toString(): String {
-        return "${declaringClass.name}::$name: $type"
-    }
-}
+)
 
 @Serializable
+@SerialName("MethodSignature")
 data class MethodSignatureDto(
     val declaringClass: ClassSignatureDto,
     val name: String,
     val parameters: List<MethodParameterDto>,
     val returnType: TypeDto,
-) {
-    override fun toString(): String {
-        val params = parameters.joinToString()
-        return "${declaringClass.name}::$name($params): $returnType"
-    }
-}
+)
 
 @Serializable
 data class MethodParameterDto(
     val name: String,
     val type: TypeDto,
     val isOptional: Boolean = false,
-) {
-    override fun toString(): String {
-        return "$name: $type"
-    }
-}
+)
 
 @Serializable
 data class LocalSignatureDto(
     val name: String,
     val method: MethodSignatureDto,
-) {
-    override fun toString(): String {
-        return "${method}#${name}"
-    }
-}
+)

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Stmts.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Stmts.kt
@@ -17,14 +17,25 @@
 package org.jacodb.ets.dto
 
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KeepGeneratedSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonObject
 
 @Serializable
 @OptIn(ExperimentalSerializationApi::class)
 @JsonClassDiscriminator("_")
 sealed interface StmtDto
+
+@Serializable(with = RawStmtSerializer::class)
+@SerialName("RawStmt")
+@OptIn(ExperimentalSerializationApi::class)
+@KeepGeneratedSerializer
+data class RawStmtDto(
+    val kind: String, // constructor name
+    val extra: JsonObject,
+) : StmtDto
 
 @Serializable
 @SerialName("NopStmt")
@@ -35,21 +46,13 @@ data object NopStmtDto : StmtDto
 data class AssignStmtDto(
     val left: ValueDto,
     val right: ValueDto,
-) : StmtDto {
-    override fun toString(): String {
-        return "$left = $right"
-    }
-}
+) : StmtDto
 
 @Serializable
 @SerialName("CallStmt")
 data class CallStmtDto(
     val expr: CallExprDto,
-) : StmtDto {
-    override fun toString(): String {
-        return expr.toString()
-    }
-}
+) : StmtDto
 
 @Serializable
 sealed interface TerminatingStmtDto : StmtDto
@@ -62,11 +65,7 @@ data object ReturnVoidStmtDto : TerminatingStmtDto
 @SerialName("ReturnStmt")
 data class ReturnStmtDto(
     val arg: ValueDto,
-) : TerminatingStmtDto {
-    override fun toString(): String {
-        return "return $arg"
-    }
-}
+) : TerminatingStmtDto
 
 @Serializable
 @SerialName("ThrowStmt")
@@ -93,10 +92,3 @@ data class SwitchStmtDto(
     val arg: ValueDto,
     val cases: List<ValueDto>,
 ) : BranchingStmtDto
-
-@Serializable
-@SerialName("RawStmt")
-data class RawStmtDto(
-    val type: String, // constructor name
-    val text: String, // toString
-) : StmtDto

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Types.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Types.kt
@@ -17,66 +17,53 @@
 package org.jacodb.ets.dto
 
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KeepGeneratedSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonObject
 
 @Serializable
 @OptIn(ExperimentalSerializationApi::class)
 @JsonClassDiscriminator("_")
 sealed interface TypeDto
 
+@Serializable(with = RawTypeSerializer::class)
+@SerialName("RawType")
+@OptIn(ExperimentalSerializationApi::class)
+@KeepGeneratedSerializer
+data class RawTypeDto(
+    val kind: String, // constructor name
+    val extra: JsonObject,
+) : TypeDto
+
 @Serializable
 @SerialName("AnyType")
-object AnyTypeDto : TypeDto {
-    override fun toString(): String {
-        return "any"
-    }
-}
+data object AnyTypeDto : TypeDto
 
 @Serializable
 @SerialName("UnknownType")
-object UnknownTypeDto : TypeDto {
-    override fun toString(): String {
-        return "unknown"
-    }
-}
+data object UnknownTypeDto : TypeDto
 
 @Serializable
 @SerialName("VoidType")
-object VoidTypeDto : TypeDto {
-    override fun toString(): String {
-        return "void"
-    }
-}
+data object VoidTypeDto : TypeDto
 
 @Serializable
 @SerialName("NeverType")
-object NeverTypeDto : TypeDto {
-    override fun toString(): String {
-        return "never"
-    }
-}
+data object NeverTypeDto : TypeDto
 
 @Serializable
 @SerialName("UnionType")
 data class UnionTypeDto(
     val types: List<TypeDto>,
-) : TypeDto {
-    override fun toString(): String {
-        return types.joinToString(" | ")
-    }
-}
+) : TypeDto
 
 @Serializable
 @SerialName("TupleType")
 data class TupleTypeDto(
     val types: List<TypeDto>,
-) : TypeDto {
-    override fun toString(): String {
-        return "[${types.joinToString()}]"
-    }
-}
+) : TypeDto
 
 @Serializable
 sealed interface PrimitiveTypeDto : TypeDto {
@@ -85,57 +72,37 @@ sealed interface PrimitiveTypeDto : TypeDto {
 
 @Serializable
 @SerialName("BooleanType")
-object BooleanTypeDto : PrimitiveTypeDto {
+data object BooleanTypeDto : PrimitiveTypeDto {
     override val name: String
         get() = "boolean"
-
-    override fun toString(): String {
-        return name
-    }
 }
 
 @Serializable
 @SerialName("NumberType")
-object NumberTypeDto : PrimitiveTypeDto {
+data object NumberTypeDto : PrimitiveTypeDto {
     override val name: String
         get() = "number"
-
-    override fun toString(): String {
-        return name
-    }
 }
 
 @Serializable
 @SerialName("StringType")
-object StringTypeDto : PrimitiveTypeDto {
+data object StringTypeDto : PrimitiveTypeDto {
     override val name: String
         get() = "string"
-
-    override fun toString(): String {
-        return name
-    }
 }
 
 @Serializable
 @SerialName("NullType")
-object NullTypeDto : PrimitiveTypeDto {
+data object NullTypeDto : PrimitiveTypeDto {
     override val name: String
         get() = "null"
-
-    override fun toString(): String {
-        return name
-    }
 }
 
 @Serializable
 @SerialName("UndefinedType")
-object UndefinedTypeDto : PrimitiveTypeDto {
+data object UndefinedTypeDto : PrimitiveTypeDto {
     override val name: String
         get() = "undefined"
-
-    override fun toString(): String {
-        return name
-    }
 }
 
 @Serializable
@@ -145,25 +112,15 @@ data class LiteralTypeDto(
 ) : PrimitiveTypeDto {
     override val name: String
         get() = literal.toString()
-
-    override fun toString(): String {
-        return name
-    }
 }
 
 @Serializable(with = PrimitiveLiteralSerializer::class)
 sealed class PrimitiveLiteralDto {
-    data class StringLiteral(val value: String) : PrimitiveLiteralDto() {
-        override fun toString(): String = value
-    }
+    data class StringLiteral(val value: String) : PrimitiveLiteralDto()
 
-    data class NumberLiteral(val value: Double) : PrimitiveLiteralDto() {
-        override fun toString(): String = value.toString()
-    }
+    data class NumberLiteral(val value: Double) : PrimitiveLiteralDto()
 
-    data class BooleanLiteral(val value: Boolean) : PrimitiveLiteralDto() {
-        override fun toString(): String = value.toString()
-    }
+    data class BooleanLiteral(val value: Boolean) : PrimitiveLiteralDto()
 }
 
 @Serializable
@@ -171,60 +128,28 @@ sealed class PrimitiveLiteralDto {
 data class ClassTypeDto(
     val signature: ClassSignatureDto,
     val typeParameters: List<TypeDto> = emptyList(),
-) : TypeDto {
-    override fun toString(): String {
-        return if (typeParameters.isNotEmpty()) {
-            val generics = typeParameters.joinToString()
-            "$signature<$generics>"
-        } else {
-            signature.toString()
-        }
-    }
-}
+) : TypeDto
 
 @Serializable
 @SerialName("FunctionType")
 data class FunctionTypeDto(
     val signature: MethodSignatureDto,
     val typeParameters: List<TypeDto> = emptyList(),
-) : TypeDto {
-    override fun toString(): String {
-        val params = signature.parameters.joinToString()
-        return if (typeParameters.isNotEmpty()) {
-            val generics = typeParameters.joinToString()
-            "${signature.name}<$generics>($params): ${signature.returnType}"
-        } else {
-            "${signature.name}($params): ${signature.returnType}"
-        }
-    }
-}
+) : TypeDto
 
 @Serializable
 @SerialName("ArrayType")
 data class ArrayTypeDto(
     val elementType: TypeDto,
     val dimensions: Int,
-) : TypeDto {
-    override fun toString(): String {
-        return "$elementType" + "[]".repeat(dimensions)
-    }
-}
+) : TypeDto
 
 @Serializable
 @SerialName("UnclearReferenceType")
 data class UnclearReferenceTypeDto(
     val name: String,
     val typeParameters: List<TypeDto> = emptyList(),
-) : TypeDto {
-    override fun toString(): String {
-        return if (typeParameters.isNotEmpty()) {
-            val generics = typeParameters.joinToString()
-            "$name<$generics>"
-        } else {
-            name
-        }
-    }
-}
+) : TypeDto
 
 @Serializable
 @SerialName("GenericType")
@@ -232,11 +157,7 @@ data class GenericTypeDto(
     val name: String,
     val defaultType: TypeDto? = null,
     val constraint: TypeDto? = null,
-) : TypeDto {
-    override fun toString(): String {
-        return name + (constraint?.let { " extends $it" } ?: "") + (defaultType?.let { " = $it" } ?: "")
-    }
-}
+) : TypeDto
 
 @Serializable
 @SerialName("AliasType")
@@ -244,40 +165,4 @@ data class AliasTypeDto(
     val name: String,
     val originalType: TypeDto,
     val signature: LocalSignatureDto,
-) : TypeDto {
-    override fun toString(): String {
-        return "$name = $originalType"
-    }
-}
-
-@Serializable
-@SerialName("AnnotationNamespaceType")
-data class AnnotationNamespaceTypeDto(
-    val originType: String,
-    val namespaceSignature: NamespaceSignatureDto,
-) : TypeDto {
-    override fun toString(): String {
-        return originType
-    }
-}
-
-@Serializable
-@SerialName("AnnotationTypeQueryType")
-data class AnnotationTypeQueryTypeDto(
-    val originType: String,
-) : TypeDto {
-    override fun toString(): String {
-        return originType
-    }
-}
-
-@Serializable
-@SerialName("LexicalEnvType")
-data class LexicalEnvTypeDto(
-    val nestedMethod: MethodSignatureDto,
-    val closures: List<LocalDto>,
-) : TypeDto {
-    override fun toString(): String {
-        return closures.joinToString(prefix = "[", postfix = "]")
-    }
-}
+) : TypeDto

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/GetOperands.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/GetOperands.kt
@@ -28,15 +28,12 @@ import org.jacodb.ets.base.EtsBitXorExpr
 import org.jacodb.ets.base.EtsBooleanConstant
 import org.jacodb.ets.base.EtsCallStmt
 import org.jacodb.ets.base.EtsCastExpr
-import org.jacodb.ets.base.EtsCaughtExceptionRef
-import org.jacodb.ets.base.EtsClosureFieldRef
 import org.jacodb.ets.base.EtsCommaExpr
 import org.jacodb.ets.base.EtsDeleteExpr
 import org.jacodb.ets.base.EtsDivExpr
 import org.jacodb.ets.base.EtsEntity
 import org.jacodb.ets.base.EtsEqExpr
 import org.jacodb.ets.base.EtsExpExpr
-import org.jacodb.ets.base.EtsGlobalRef
 import org.jacodb.ets.base.EtsGotoStmt
 import org.jacodb.ets.base.EtsGtEqExpr
 import org.jacodb.ets.base.EtsGtExpr
@@ -67,6 +64,7 @@ import org.jacodb.ets.base.EtsPostIncExpr
 import org.jacodb.ets.base.EtsPreDecExpr
 import org.jacodb.ets.base.EtsPreIncExpr
 import org.jacodb.ets.base.EtsPtrCallExpr
+import org.jacodb.ets.base.EtsRawEntity
 import org.jacodb.ets.base.EtsRawStmt
 import org.jacodb.ets.base.EtsRemExpr
 import org.jacodb.ets.base.EtsReturnStmt
@@ -303,12 +301,6 @@ private object EntityGetOperands : EtsEntity.Visitor<Sequence<EtsEntity>> {
     override fun visit(expr: EtsTernaryExpr): Sequence<EtsEntity> =
         sequenceOf(expr.condition, expr.thenExpr, expr.elseExpr)
 
-    override fun visit(value: EtsCaughtExceptionRef): Sequence<EtsEntity> =
+    override fun visit(value: EtsRawEntity): Sequence<EtsEntity> =
         emptySequence()
-
-    override fun visit(value: EtsGlobalRef): Sequence<EtsEntity> =
-        if (value.ref != null) sequenceOf(value.ref) else emptySequence()
-
-    override fun visit(value: EtsClosureFieldRef): Sequence<EtsEntity> =
-        sequenceOf(value.base)
 }


### PR DESCRIPTION
This PR adds "Raw" (or rather, "unrecognized", "unsupported", "unknown", "unhandled") statements/values/types with custom de/serializers. This PR also removes all `toString()` for DTOs, because `toString()` is only meaningful for the "real" objects in Ets hierarchy.