### PR TITLE
Bump actions in CI workflow, allow Gradle cache for 'neo' branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,17 +38,17 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'zulu'
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
         with:
           # Only write to the cache for builds on the specific branches. (Default is 'main' only.)
           # Builds on other branches will only read existing entries from the cache.
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' && github.ref != 'ref/heads/neo' }}
 
       - name: Set up GraphViz
         uses: ts-graphviz/setup-graphviz@v2
@@ -92,7 +92,7 @@ jobs:
         run: ./gradlew :jacodb-ets:test --scan
 
       - name: Build and run tests
-        run: ./gradlew build --stacktrace --scan
+        run: ./gradlew build --scan
 
       - name: Publish test results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -127,20 +127,20 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: 'zulu'
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
         with:
           # Only write to the cache for builds on the specific branches. (Default is 'main' only.)
           # Builds on other branches will only read existing entries from the cache.
-          cache-read-only: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/develop' }}
+          cache-read-only: ${{ github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/neo' }}
 
       - name: Build and run lifecycle tests
-        run: ./gradlew lifecycleTest --stacktrace --scan
+        run: ./gradlew lifecycleTest --scan
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
       main_jdk: 8
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java
         uses: actions/setup-java@v4
@@ -124,7 +124,7 @@ jobs:
     name: Run lifecycle tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
This PR updates the versions of some actions in GHA workflow, and enables Gradle cache for `neo` branch.