### PR TITLE
Add ProcessUtil

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/Dot.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/Dot.kt
@@ -44,7 +44,11 @@ fun render(
             "-o",
             "$formatFile"
         )
-        runProcess(cmd, 10.seconds)
-        logger.info { "Generated ${format.uppercase()} file: ${formatFile.absolute()}" }
+        val res = ProcessUtil.run(cmd, timeout = 30.seconds)
+        if (res.isTimeout) {
+            logger.error { "Rendering DOT to ${format.uppercase()} timed out" }
+        } else {
+            logger.info { "Generated ${format.uppercase()} file: ${formatFile.absolute()}" }
+        }
     }
 }

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/LoadEtsFile.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/LoadEtsFile.kt
@@ -26,12 +26,14 @@ import kotlin.io.path.Path
 import kotlin.io.path.PathWalkOption
 import kotlin.io.path.absolute
 import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
 import kotlin.io.path.exists
 import kotlin.io.path.extension
 import kotlin.io.path.inputStream
 import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.pathString
 import kotlin.io.path.walk
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 private const val ENV_VAR_ARK_ANALYZER_DIR = "ARKANALYZER_DIR"
@@ -48,6 +50,7 @@ fun generateEtsIR(
     isProject: Boolean = false,
     loadEntrypoints: Boolean = true,
     useArkAnalyzerTypeInference: Int? = null,
+    timeout: Duration? = 10.seconds,
 ): Path {
     val arkAnalyzerDir = Path(System.getenv(ENV_VAR_ARK_ANALYZER_DIR) ?: DEFAULT_ARK_ANALYZER_DIR)
     if (!arkAnalyzerDir.exists()) {
@@ -70,9 +73,9 @@ fun generateEtsIR(
 
     val node = System.getenv(ENV_VAR_NODE_EXECUTABLE) ?: DEFAULT_NODE_EXECUTABLE
     val output = if (isProject) {
-        createTempDirectory(prefix = projectPath.nameWithoutExtension)
+        createTempDirectory(projectPath.nameWithoutExtension)
     } else {
-        kotlin.io.path.createTempFile(prefix = projectPath.nameWithoutExtension, suffix = ".json")
+        createTempFile(projectPath.nameWithoutExtension, suffix = ".json")
     }
 
     val cmd = listOfNotNull(
@@ -84,7 +87,7 @@ fun generateEtsIR(
         projectPath.pathString,
         output.pathString,
     )
-    runProcess(cmd, 10.seconds)
+    ProcessUtil.run(cmd, timeout = timeout)
     return output
 }
 

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/LoadEtsFile.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/LoadEtsFile.kt
@@ -16,6 +16,7 @@
 
 package org.jacodb.ets.utils
 
+import mu.KotlinLogging
 import org.jacodb.ets.dto.EtsFileDto
 import org.jacodb.ets.dto.toEtsFile
 import org.jacodb.ets.model.EtsFile
@@ -35,6 +36,8 @@ import kotlin.io.path.pathString
 import kotlin.io.path.walk
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+
+private val logger = KotlinLogging.logger {}
 
 private const val ENV_VAR_ARK_ANALYZER_DIR = "ARKANALYZER_DIR"
 private const val DEFAULT_ARK_ANALYZER_DIR = "arkanalyzer"
@@ -86,8 +89,18 @@ fun generateEtsIR(
         useArkAnalyzerTypeInference?.let { "-t $it" },
         projectPath.pathString,
         output.pathString,
+        "-v",
     )
-    ProcessUtil.run(cmd, timeout = timeout)
+    val res = ProcessUtil.run(cmd, timeout = timeout)
+    if (res.exitCode != 0) {
+        logger.error { "ARKANALYZER failed with exit code ${res.exitCode}" }
+        logger.error { "STDOUT:\n${res.stdout}" }
+        logger.error { "STDERR:\n${res.stderr}" }
+    } else if (res.isTimeout) {
+        logger.error { "ARKANALYZER timed out after $timeout" }
+        logger.error { "STDOUT:\n${res.stdout}" }
+        logger.error { "STDERR:\n${res.stderr}" }
+    }
     return output
 }
 

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/ProcessUtil.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/ProcessUtil.kt
@@ -1,0 +1,92 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jacodb.ets.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.io.Reader
+
+object ProcessUtil {
+    fun run(command: List<String>, input: String? = null): String {
+        val reader = input?.reader() ?: "".reader()
+        return run(command, reader)
+    }
+
+    fun run(command: List<String>, input: Reader): String {
+        val process = ProcessBuilder(command).start()
+        return communicate(process, input)
+    }
+
+    private fun communicate(process: Process, input: Reader): String {
+        val stdout = StringBuilder()
+        val stderr = StringBuilder()
+
+        val scope = CoroutineScope(Dispatchers.IO)
+
+        // Handle process input
+        val stdinJob = scope.launch {
+            process.outputWriter().use { writer ->
+                input.copyTo(writer)
+            }
+        }
+
+        // Launch output capture coroutines
+        val stdoutJob = scope.launch {
+            process.inputReader().useLines { lines ->
+                lines.forEach { stdout.appendLine(it) }
+            }
+        }
+        val stderrJob = scope.launch {
+            process.errorReader().useLines { lines ->
+                lines.forEach { stderr.appendLine(it) }
+            }
+        }
+
+        // Wait for completion
+        val exitCode = process.waitFor()
+        runBlocking {
+            stdinJob.join()
+            stdoutJob.join()
+            stderrJob.join()
+        }
+
+        if (exitCode != 0) {
+            throw ProcessException(
+                "Process failed with exit code $exitCode",
+                exitCode,
+                stderr.toString()
+            )
+        }
+
+        return stdout.toString()
+    }
+
+    class ProcessException(
+        message: String,
+        val exitCode: Int,
+        val errorOutput: String,
+    ) : RuntimeException(message)
+}
+
+fun main() {
+    // Note: `ls -l /bin/` has big enough output to demonstrate the necessity
+    //   of separate output capture threads/coroutines.
+    val output = ProcessUtil.run(listOf("ls", "-l", "/bin/"))
+    println(output)
+}

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/ProcessUtil.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/ProcessUtil.kt
@@ -41,19 +41,19 @@ object ProcessUtil {
 
         // Handle process input
         val stdinJob = scope.launch {
-            process.outputWriter().use { writer ->
+            process.outputStream.bufferedWriter().use { writer ->
                 input.copyTo(writer)
             }
         }
 
         // Launch output capture coroutines
         val stdoutJob = scope.launch {
-            process.inputReader().useLines { lines ->
+            process.inputStream.bufferedReader().useLines { lines ->
                 lines.forEach { stdout.appendLine(it) }
             }
         }
         val stderrJob = scope.launch {
-            process.errorReader().useLines { lines ->
+            process.errorStream.bufferedReader().useLines { lines ->
                 lines.forEach { stderr.appendLine(it) }
             }
         }

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/ProcessUtil.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/ProcessUtil.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import java.io.Reader
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 
 private val logger = KotlinLogging.logger {}
 
@@ -37,7 +38,7 @@ object ProcessUtil {
     fun run(
         command: List<String>,
         input: String? = null,
-        timeout: Long? = null,
+        timeout: Duration? = null,
     ): Result {
         val reader = input?.reader() ?: "".reader()
         return run(command, reader, timeout)
@@ -46,7 +47,7 @@ object ProcessUtil {
     fun run(
         command: List<String>,
         input: Reader,
-        timeout: Long? = null,
+        timeout: Duration? = null,
     ): Result {
         logger.debug { "Running command: $command" }
         val process = ProcessBuilder(command).start()
@@ -56,7 +57,7 @@ object ProcessUtil {
     private fun communicate(
         process: Process,
         input: Reader,
-        timeout: Long? = null,
+        timeout: Duration? = null,
     ): Result {
         val stdout = StringBuilder()
         val stderr = StringBuilder()
@@ -84,7 +85,7 @@ object ProcessUtil {
 
         // Wait for completion
         val isTimeout = if (timeout != null) {
-            !process.waitFor(timeout, TimeUnit.SECONDS)
+            !process.waitFor(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
         } else {
             process.waitFor()
             false

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/Utils.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/Utils.kt
@@ -16,53 +16,8 @@
 
 package org.jacodb.ets.utils
 
-import mu.KotlinLogging
 import org.jacodb.ets.dto.EtsFileDto
 import org.jacodb.ets.model.EtsFile
-import java.nio.file.Path
-import java.util.concurrent.TimeUnit
-import kotlin.time.Duration
-
-private val logger = KotlinLogging.logger {}
-
-internal fun runProcess(cmd: List<String>, timeout: Duration? = null) {
-    logger.info { "Running: '${cmd.joinToString(" ")}'" }
-    val process = ProcessBuilder(cmd).start()
-    val ok = if (timeout == null) {
-        process.waitFor()
-        true
-    } else {
-        process.waitFor(timeout.inWholeNanoseconds, TimeUnit.NANOSECONDS)
-    }
-
-    val stdout = process.inputStream.bufferedReader().readText().trim()
-    if (stdout.isNotBlank()) {
-        logger.info { "STDOUT:\n$stdout" }
-    }
-    val stderr = process.errorStream.bufferedReader().readText().trim()
-    if (stderr.isNotBlank()) {
-        logger.info { "STDERR:\n$stderr" }
-    }
-
-    if (!ok) {
-        logger.info { "Timeout!" }
-        process.destroy()
-    }
-}
-
-/**
- * Returns the path to the sibling of this path with the given name.
- *
- * Usage:
- * ```
- * val path = Path("foo/bar.jpeg")
- * val sibling = path.resolveSibling { it.nameWithoutExtension + ".png" }
- * println(sibling) // foo/bar.png
- * ```
- */
-internal fun Path.resolveSibling(name: (Path) -> String): Path {
-    return resolveSibling(name(this))
-}
 
 fun EtsFileDto.toText(): String {
     val lines: MutableList<String> = mutableListOf()


### PR DESCRIPTION
This PR adds the utility function `ProcessUtil.run` similar to `Util.sh` from `jdot`, but better (written in Kotlin and using coroutines).

- [x] Add timeout support.
- [x] ~Show the captured output (stdout/stderr) in case of execution failure (`exitCode != 0`).~
- [x] Store captured output (stdout/stderr).
- [x] Use `ProcessUtil.run` instead of ad-hoc `runProcess`.
- [ ] ~Add unit tests.~