### PR TITLE
Support mutable locations

### DIFF
--- a/jacodb-benchmarks/build.gradle.kts
+++ b/jacodb-benchmarks/build.gradle.kts
@@ -85,6 +85,9 @@ benchmark {
             include("RAMEntityRelationshipStorageMutableBenchmarks")
             include("RAMEntityRelationshipStorageImmutableBenchmarks")
         }
+        register("hash") {
+            include("HashBenchmarks")
+        }
     }
 }
 

--- a/jacodb-benchmarks/src/test/kotlin/org/jacodb/testing/performance/hash/HashBenchmarks.kt
+++ b/jacodb-benchmarks/src/test/kotlin/org/jacodb/testing/performance/hash/HashBenchmarks.kt
@@ -1,0 +1,91 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage", "DEPRECATION")
+
+package org.jacodb.testing.performance.hash
+
+import com.google.common.hash.Hasher
+import com.google.common.hash.Hashing
+import kotlinx.benchmark.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Warmup
+import java.security.SecureRandom
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@Measurement(iterations = 5, time = 1)
+class HashBenchmarks {
+
+    companion object {
+        val array = ByteArray(1_000_000).also { SecureRandom().nextBytes(it) }
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun createSip24Hasher(): Hasher {
+        return Hashing.sipHash24().newHasher()
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun createMurMur3Hasher(): Hasher {
+        return Hashing.murmur3_128().newHasher()
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun createMd5Hasher(): Hasher {
+        return Hashing.md5().newHasher()
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.NANOSECONDS)
+    fun createSha256Hasher(): Hasher {
+        return Hashing.sha256().newHasher()
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    fun sip24Hash(): Long {
+        return Hashing.sipHash24().newHasher().putBytes(array).hash().asLong()
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    fun murMur3Hash(): Long {
+        return Hashing.murmur3_128().newHasher().putBytes(array).hash().asLong()
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    fun sha256Hash(): Long {
+        return Hashing.sha256().newHasher().putBytes(array).hash().asLong()
+    }
+
+    @Benchmark
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    fun md5Hash(): Long {
+        return Hashing.md5().newHasher().putBytes(array).hash().asLong()
+    }
+}

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/features/Diagnostics.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/features/Diagnostics.kt
@@ -21,6 +21,7 @@ package org.jacodb.impl.features
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
 import org.jacodb.api.jvm.JcClasspath
+import org.jacodb.impl.storage.ers.filterDeleted
 import org.jacodb.impl.storage.execute
 import org.jacodb.impl.storage.jooq.tables.references.CLASSES
 import org.jacodb.impl.storage.jooq.tables.references.SYMBOLS
@@ -48,7 +49,7 @@ suspend fun JcClasspath.duplicatedClasses(): Map<String, Int> {
             },
             noSqlAction = { txn ->
                 val result = mutableMapOf<String, Int>().also { result ->
-                    txn.all("Class").forEach { clazz ->
+                    txn.all("Class").filterDeleted().forEach { clazz ->
                         val className = persistence.findSymbolName(clazz.getCompressed<Long>("nameId")!!)
                         result[className] = result.getOrDefault(className, 0) + 1
                     }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/ByteCodeLocations.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/ByteCodeLocations.kt
@@ -62,7 +62,7 @@ private fun File.classPath(classpath: MutableCollection<File>) {
     }
 }
 
-private fun File.isJar() = isFile && name.endsWith(".jar") || name.endsWith(".jmod")
+fun File.isJar() = isFile && name.endsWith(".jar") || name.endsWith(".jmod")
 
 private const val file = "file:"
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/JarLocationImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/JarLocationImpl.kt
@@ -39,13 +39,15 @@ open class JarLocation(
         get() {
             val jarFile = jarFile() ?: return BigInteger.ZERO
             return Hashing.sha256().newHasher().let { h ->
-                jarFile.entries().asSequence().filter { !it.isDirectory }.sortedBy { it.name }.forEach { entry ->
-                    h.putString(entry.name, UTF_8)
-                    h.putLong(entry.crc)
-                    h.putLong(entry.size)
-                    h.putLong(entry.compressedSize)
+                jarFile.use {
+                    it.entries().asSequence().filter { !it.isDirectory }.sortedBy { it.name }.forEach { entry ->
+                        h.putString(entry.name, UTF_8)
+                        h.putLong(entry.crc)
+                        h.putLong(entry.size)
+                        h.putLong(entry.compressedSize)
+                    }
+                    BigInteger(h.hash().asBytes())
                 }
-                BigInteger(h.hash().asBytes())
             }
         }
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/Jars.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/fs/Jars.kt
@@ -85,7 +85,7 @@ class JarFacade(private val runtimeVersion: Int, private val getter: () -> JarFi
             val jarFile = getter() ?: return emptyMap()
             return jarFile.use {
                 val buffer = ByteArray(DEFAULT_BUFFER_SIZE * 8)
-                classes.map { it.key to jarFile.getInputStream(it.value).readBytes(buffer) }
+                classes.map { it.key to jarFile.getInputStream(it.value).use { it.readBytes(buffer) } }
             }.toMap()
         }
 

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/PersistentLocationsRegistry.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/PersistentLocationsRegistry.kt
@@ -163,7 +163,7 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
             val result = arrayListOf<RegisteredLocation>()
             val toAdd = arrayListOf<JcByteCodeLocation>()
             val fsIds = uniqueLocations.map { it.fileSystemId }
-            val existed = context.execute(
+            val existing = context.execute(
                 sqlAction = { jooq ->
                     jooq.selectFrom(BYTECODELOCATIONS).where(BYTECODELOCATIONS.UNIQUEID.`in`(fsIds)).map { record ->
                         PersistentByteCodeLocationData.fromSqlRecord(record)
@@ -181,7 +181,7 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
             ).associateBy { it.fileSystemId }
 
             uniqueLocations.forEach {
-                val found = existed[it.fileSystemId]
+                val found = existing[it.fileSystemId]
                 if (found == null) {
                     toAdd += it
                 } else {
@@ -345,9 +345,9 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
     }
 
     private fun JcByteCodeLocation.findOrNew(context: StorageContext): PersistentByteCodeLocationData {
-        val existed = findOrNull(context)
-        if (existed != null) {
-            return existed
+        val existing = findOrNull(context)
+        if (existing != null) {
+            return existing
         }
         return context.execute(
             sqlAction = { jooq ->
@@ -360,7 +360,12 @@ class PersistentLocationsRegistry(private val jcdb: JcDatabaseImpl) : LocationsR
                 PersistentByteCodeLocationData.fromSqlRecord(record)
             },
             noSqlAction = { txn ->
-                val entity = txn.newEntity(BytecodeLocationEntity.BYTECODE_LOCATION_ENTITY_TYPE)
+                val entity =
+                    txn.find(
+                        type = BytecodeLocationEntity.BYTECODE_LOCATION_ENTITY_TYPE,
+                        propertyName = BytecodeLocationEntity.PATH,
+                        value = path
+                    ).firstOrNull() ?: txn.newEntity(BytecodeLocationEntity.BYTECODE_LOCATION_ENTITY_TYPE)
                 entity[BytecodeLocationEntity.PATH] = path
                 entity[BytecodeLocationEntity.FILE_SYSTEM_ID] = fileSystemId
                 entity[BytecodeLocationEntity.IS_RUNTIME] = type == LocationType.RUNTIME

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ErsExt.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ErsExt.kt
@@ -18,19 +18,93 @@ package org.jacodb.impl.storage.ers
 
 import org.jacodb.api.jvm.ClassSource
 import org.jacodb.api.jvm.JcDatabase
+import org.jacodb.api.jvm.JcDatabasePersistence
 import org.jacodb.api.storage.ers.Entity
-import org.jacodb.impl.fs.PersistenceClassSource
+import org.jacodb.api.storage.ers.compressed
+import org.jacodb.api.storage.ers.getEntityOrNull
+import org.jacodb.impl.storage.txn
+
+fun Entity.toClassSource(
+    persistence: JcDatabasePersistence,
+    className: String,
+    nameId: Long,
+    cachedByteCode: ByteArray? = null
+): ClassSource =
+    ErsClassSource(
+        persistence = persistence as ErsPersistenceImpl,
+        className = className,
+        nameId = nameId,
+        classId = id.instanceId,
+        locationId = requireNotNull(getCompressed<Long>("locationId")) { "locationId property isn't set" },
+        cachedByteCode = cachedByteCode
+    )
 
 fun Sequence<Entity>.toClassSourceSequence(db: JcDatabase): Sequence<ClassSource> {
     val persistence = db.persistence
     return map { clazz ->
-        val classId: Long = clazz.id.instanceId
-        PersistenceClassSource(
-            db = db,
-            className = persistence.findSymbolName(clazz.getCompressed<Long>("nameId")!!),
-            classId = classId,
-            locationId = clazz.getCompressed<Long>("locationId")!!,
-            cachedByteCode = persistence.findBytecode(classId)
-        )
+        val nameId = requireNotNull(clazz.getCompressed<Long>("nameId")) { "nameId property isn't set" }
+        clazz.toClassSource(persistence, persistence.findSymbolName(nameId), nameId)
+    }
+}
+
+fun Sequence<Entity>.filterDeleted(): Sequence<Entity> = filter { it.get<Boolean>("isDeleted") != true }
+
+fun Sequence<Entity>.filterLocations(locationIds: Set<Long>): Sequence<Entity> = filter {
+    it.getCompressed<Long>("locationId") in locationIds
+}
+
+fun Sequence<Entity>.filterLocations(locationId: Long): Sequence<Entity> = filter {
+    it.getCompressed<Long>("locationId") == locationId
+}
+
+fun <T> Sequence<T>.exactSingleOrNull(): T? {
+    val it = iterator()
+    if (!it.hasNext()) return null
+    return it.next().apply {
+        check(!it.hasNext()) {
+            "Sequence should have exactly one element or no elements"
+        }
+    }
+}
+
+private class ErsClassSource(
+    private val persistence: ErsPersistenceImpl,
+    override val className: String,
+    private val nameId: Long,
+    private var classId: Long,
+    private val locationId: Long,
+    private var cachedByteCode: ByteArray?
+) : ClassSource {
+
+    override val byteCode: ByteArray
+        get() {
+            val prevClassId = classId
+            val checkedClassId = checkClassId()
+            return if (prevClassId == checkedClassId && cachedByteCode != null) {
+                cachedByteCode!!
+            } else {
+                persistence.findBytecode(checkedClassId).also {
+                    cachedByteCode?.let {
+                        cachedByteCode = it
+                    }
+                }
+            }
+        }
+
+    override val location = persistence.findLocation(locationId)
+
+    private fun checkClassId(): Long = persistence.read { context ->
+        val txn = context.txn
+        var result = txn.getEntityOrNull("Class", classId)
+        // Since location is mutable, class entity can become expired (deleted)
+        // In that case, we have to re-evaluate it
+        if (result == null || result.get<Boolean>("isDeleted") == true) {
+            result = txn.find("Class", "nameId", nameId.compressed)
+                .filterDeleted()
+                .filterLocations(locationId)
+                .single()
+            classId = result.id.instanceId
+        }
+        classId
     }
 }

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/features/InMemoryHierarchyTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/features/InMemoryHierarchyTest.kt
@@ -24,6 +24,7 @@ import org.jacodb.impl.features.InMemoryHierarchy
 import org.jacodb.impl.features.findSubclassesInMemory
 import org.jacodb.impl.features.hierarchyExt
 import org.jacodb.impl.storage.dslContext
+import org.jacodb.impl.storage.ers.filterDeleted
 import org.jacodb.impl.storage.jooq.tables.references.CLASSES
 import org.jacodb.impl.storage.txn
 import org.jacodb.testing.BaseTest
@@ -99,7 +100,8 @@ abstract class BaseInMemoryHierarchyTest : BaseTest() {
         assertEquals(numberOfClasses - 1, findSubClasses<Any>(allHierarchy = true).count())
     }
 
-    protected open fun getNumberOfClasses(): Int = cp.db.persistence.read { it.txn.all("Class").size.toInt() }
+    protected open fun getNumberOfClasses(): Int =
+        cp.db.persistence.read { it.txn.all("Class").filterDeleted().count() }
 
     @Test
     fun `find subclasses of Comparable`() {

--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/persistence/incrementality/IncrementalDbTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/persistence/incrementality/IncrementalDbTest.kt
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2022 UnitTestBot contributors (utbot.org)
+ * <p>
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ * <p>
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.jacodb.testing.persistence.incrementality
+
+import kotlinx.coroutines.runBlocking
+import org.jacodb.api.jvm.ext.findClass
+import org.jacodb.testing.WithDb
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Files.createDirectories
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.Path
+import kotlin.io.path.createTempDirectory
+
+class IncrementalDbTest {
+
+    companion object : WithDb() {
+        private val keap_0_2_1 = "https://repo1.maven.org/maven2/com/github/penemue/keap/0.2.1/keap-0.2.1.jar"
+        private val keap_0_2_2 = "https://repo1.maven.org/maven2/com/github/penemue/keap/0.2.2/keap-0.2.2.jar"
+    }
+
+    @Test
+    fun `two keaps`(): Unit = runBlocking {
+        val modelJar = createTempJar("model.jar")
+        val firstJar = cookJar(keap_0_2_1)
+        Files.copy(firstJar, modelJar, StandardCopyOption.REPLACE_EXISTING)
+        val cp = db.classpath(listOf(modelJar.toFile()))
+        db.awaitBackgroundJobs()
+        val bc1 = cp.findClass("com.github.penemue.keap.PriorityQueue").bytecode()
+        // overwrite jar
+        Files.copy(cookJar(keap_0_2_2), modelJar, StandardCopyOption.REPLACE_EXISTING)
+        db.refresh()
+        db.awaitBackgroundJobs()
+        Assertions.assertFalse(bc1 contentEquals cp.findClass("com.github.penemue.keap.PriorityQueue").bytecode())
+        // rollback jar
+        Files.copy(firstJar, modelJar, StandardCopyOption.REPLACE_EXISTING)
+        db.refresh()
+        db.awaitBackgroundJobs()
+        Assertions.assertTrue(bc1 contentEquals cp.findClass("com.github.penemue.keap.PriorityQueue").bytecode())
+    }
+
+    private fun cookJar(link: String): Path {
+        val url = URL(link)
+        val result = createTempJar(url.file)
+        Files.copy(url.openStream(), result, StandardCopyOption.REPLACE_EXISTING)
+        return result
+    }
+
+    private fun createTempJar(name: String) =
+        Path(createTempDirectory("jcdb-temp-jar").toString(), name).also {
+            createDirectories(it.parent)
+        }
+}


### PR DESCRIPTION
[jacodb-core] Minor: reduce number of downloads

Two versions of the Keap lib are downloaded twice, not three times.

[jacodb-core] Make code model with ERS backend mutable incremental

As of this commit, ErsPersistenceImpl has got the following additional features:
- For any location and class name, there can exist several entities.
- Amongst those entities, only one is active (current), other are logically deleted, i.e. marked with "isDeleted" property.
- Any location identified by its id can be forced to be re-indexed. Only changed classes are getting the new version during re-indexing.
- For binding Persistence layer with the layer of JcDatabase, a new ClassSource implementation introduced. For getting class' byte code, this implementation checks if class id which it holds is up-to-date.
- Code model re-indexes changed locations after JcDatabase.refresh() is invoked.

TODO. PersistentLocationsRegistry looks overcomplicated. JcLocation implementations look as hacks in order to get JcLocation.isChanged() working, and in order to reindex mutated locations in-place without adding/removing them. So this part looks as a good candidate for complete rewriting.

[jacodb-core] Ensure that jar file is closed

Two resource leaks fixed: a jar file wasn't closed after
- its hash was computed;
- its classes were indexed.