### PR TITLE
Update `actions/upload-artifact` to `v4`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -107,14 +107,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       # - name: Upload test results
-      #   uses: actions/upload-artifact@v3
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: test-results
       #     path: build/test-results/
 
       - name: Upload Gradle reports
         if: (!cancelled()) && matrix.jdk == env.main_jdk
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gradle-reports
           path: '**/build/reports/'


### PR DESCRIPTION
This PR bumps `upload-artifact` action to `v4` in GHA workflow.

See: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/