### PR TITLE
Bytecode blobs

### DIFF
--- a/jacodb-api-storage/build.gradle.kts
+++ b/jacodb-api-storage/build.gradle.kts
@@ -1,4 +1,3 @@
 dependencies {
-    api(project(":jacodb-api-common"))
     api(Libs.kotlinx_collections_immutable)
 }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/AbstractJcDbPersistence.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/AbstractJcDbPersistence.kt
@@ -26,6 +26,7 @@ import org.jacodb.impl.caches.xodus.XODUS_CACHE_PROVIDER_ID
 import org.jacodb.impl.fs.JavaRuntime
 import org.jacodb.impl.fs.asByteCodeLocation
 import org.jacodb.impl.fs.logger
+import org.jacodb.impl.storage.ers.bytecode
 import org.jacodb.impl.storage.jooq.tables.references.BYTECODELOCATIONS
 import org.jacodb.impl.storage.jooq.tables.references.CLASSES
 import java.io.File
@@ -88,7 +89,7 @@ abstract class AbstractJcDbPersistence(
                         jooq.select(CLASSES.BYTECODE).from(CLASSES).where(CLASSES.ID.eq(classId)).fetchAny()?.value1()
                     },
                     noSqlAction = { txn ->
-                        txn.getEntityOrNull("Class", classId)?.getRawBlob("bytecode")
+                        txn.getEntityOrNull("Class", classId).bytecode()
                     }
                 )
             } ?: throw IllegalArgumentException("Can't find bytecode for $classId")

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ErsExt.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ErsExt.kt
@@ -67,6 +67,19 @@ fun <T> Sequence<T>.exactSingleOrNull(): T? {
     }
 }
 
+val Entity?.bytecode: LazyBytecode get() = LazyBytecode(this)
+
+class LazyBytecode(private val clazz: Entity?) {
+
+    private val blobName = "bytecode${notNullClass().id.instanceId and 0xff}"
+
+    operator fun invoke(): ByteArray? = clazz?.getRawBlob(blobName)
+
+    operator fun invoke(bytecode: ByteArray?) = notNullClass().setRawBlob(blobName, bytecode)
+
+    private fun notNullClass(): Entity = requireNotNull(clazz) { "Class entity cannot be null" }
+}
+
 private class ErsClassSource(
     private val persistence: ErsPersistenceImpl,
     override val className: String,

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ErsPersistenceImpl.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/ers/ErsPersistenceImpl.kt
@@ -126,7 +126,7 @@ class ErsPersistenceImpl(
                 val bytecode = classInfo.bytecode
                 val hc = bytecode.hash()
                 if (oldie != null) {
-                    if (oldie.get<Long>("hc") == hc && oldie.getRawBlob("bytecode") contentEquals bytecode) {
+                    if (oldie.get<Long>("hc") == hc && oldie.bytecode() contentEquals bytecode) {
                         // class hasn't changed
                         continue
                     }
@@ -135,7 +135,7 @@ class ErsPersistenceImpl(
                         .filterLocations(locationId)
                         .filter {
                             it.getCompressed<Long>("nameId") == classNameId &&
-                                    it.getRawBlob("bytecode") contentEquals bytecode
+                                    it.bytecode() contentEquals bytecode
                         }
                         .exactSingleOrNull()
                     if (sameClass != null) {
@@ -153,7 +153,7 @@ class ErsPersistenceImpl(
                     oldie?.set("isDeleted", true)
                     clazz["nameId"] = classNameId.compressed
                     clazz["locationId"] = locationIdValue
-                    clazz.setRawBlob("bytecode", bytecode)
+                    clazz.bytecode(bytecode)
                     clazz["hc"] = hc
                     classInfo.annotations.forEach { annotationInfo ->
                         annotationInfo.save(txn, clazz, RefKind.CLASS)


### PR DESCRIPTION
[jacodb-storage] Deal with bytecode using sharded blob names instead of single one

At most, 256 sharded blob names can be used for saving bytecode of class entities. A blob name is selected by instance id of a class entity in assumption that instance ids are uniformly distributed.

[jacodb-storage-api] Remove unnecessary dependency