### PR TITLE
Fix dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,5 @@
 kotlin.code.style=official
-
-intellij_community_url=https://download-cdn.jetbrains.com/idea/ideaIC-2022.2.3.win.zip
+intellij_community_url=https://download-cdn.jetbrains.com/idea/ideaIC-2024.3.2.2.win.zip
 #database_location=d:\\work\\jacodb\\jcdb-http.db
 
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/AppVersion.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/AppVersion.kt
@@ -31,11 +31,11 @@ data class AppVersion(val major: Int, val minor: Int) : Comparable<AppVersion> {
         fun read(context: StorageContext): AppVersion {
             return try {
                 val appVersion = context.execute(
-                    sqlAction = { jooq ->
-                        jooq.selectFrom(APPLICATIONMETADATA).fetch().firstOrNull()
+                    sqlAction = {
+                        context.dslContext.selectFrom(APPLICATIONMETADATA).fetch().firstOrNull()
                     },
-                    noSqlAction = { txn ->
-                        txn.all("ApplicationMetadata").firstOrNull()?.let { it["version"] }
+                    noSqlAction = {
+                        context.txn.all("ApplicationMetadata").firstOrNull()?.let { it["version"] }
                     }
                 )
                 appVersion?.run {
@@ -67,13 +67,15 @@ data class AppVersion(val major: Int, val minor: Int) : Comparable<AppVersion> {
 
     fun write(context: StorageContext) {
         context.execute(
-            sqlAction = { jooq ->
+            sqlAction = {
+                val jooq = context.dslContext
                 jooq.deleteFrom(APPLICATIONMETADATA).execute()
                 jooq.insertInto(APPLICATIONMETADATA)
                     .set(APPLICATIONMETADATA.VERSION, "$major.$minor")
                     .execute()
             },
-            noSqlAction = { txn ->
+            noSqlAction = {
+                val txn = context.txn
                 val metadata = txn.all("ApplicationMetadata").firstOrNull()
                     ?: context.txn.newEntity("ApplicationMetadata")
                 metadata["version"] = "$major.$minor"

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/JcRefactoring.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/JcRefactoring.kt
@@ -44,7 +44,8 @@ class JcRefactoringChain(private val chain: List<JcRefactoring>) {
     @OptIn(ExperimentalTime::class)
     fun execute(context: StorageContext) {
         context.execute(
-            sqlAction = { jooq ->
+            sqlAction = {
+                val jooq = context.dslContext
                 val applied = hashSetOf<String>()
                 try {
                     applied.addAll(jooq.select(REFACTORINGS.NAME).from(REFACTORINGS).fetchArray(REFACTORINGS.NAME))
@@ -63,7 +64,8 @@ class JcRefactoringChain(private val chain: List<JcRefactoring>) {
                     }
                 }
             },
-            noSqlAction = { txn ->
+            noSqlAction = {
+                val txn = context.txn
                 chain.forEach { refactoring ->
                     val refactoringName = refactoring.name
                     if (txn.find(REFACTORING_TYPE, "name", refactoringName).isEmpty) {

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/PersistentByteCodeLocation.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/PersistentByteCodeLocation.kt
@@ -73,11 +73,13 @@ class PersistentByteCodeLocation(
     val data by lazy {
         cachedData ?: persistence.read { context ->
             context.execute(
-                sqlAction = { jooq ->
+                sqlAction = {
+                    val jooq = context.dslContext
                     val record = jooq.fetchOne(BYTECODELOCATIONS, BYTECODELOCATIONS.ID.eq(id))!!
                     PersistentByteCodeLocationData.fromSqlRecord(record)
                 },
-                noSqlAction = { txn ->
+                noSqlAction = {
+                    val txn = context.txn
                     val entity = txn.getEntityOrNull(BytecodeLocationEntity.BYTECODE_LOCATION_ENTITY_TYPE, id)!!
                     PersistentByteCodeLocationData.fromErsEntity(entity)
                 }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/SqlContext.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/SqlContext.kt
@@ -18,7 +18,6 @@ package org.jacodb.impl.storage
 
 import org.jacodb.api.storage.ContextProperty
 import org.jacodb.api.storage.StorageContext
-import org.jacodb.api.storage.ers.Transaction
 import org.jacodb.api.storage.invoke
 import org.jooq.DSLContext
 import java.sql.Connection
@@ -42,11 +41,11 @@ val StorageContext.connection: Connection get() = getContextObject(ConnectionPro
 
 val StorageContext.isSqlContext: Boolean get() = hasContextObject(DSLContextProperty)
 
-fun <T> StorageContext.execute(sqlAction: (DSLContext) -> T, noSqlAction: (Transaction) -> T): T {
-    return if (isSqlContext) {
-        sqlAction(dslContext)
-    } else if (isErsContext) {
-        noSqlAction(txn)
+fun <T> StorageContext.execute(sqlAction: () -> T, noSqlAction: () -> T): T {
+    return if (isErsContext) {
+        noSqlAction()
+    } else if (isSqlContext) {
+        sqlAction()
     } else {
         throw IllegalArgumentException("StorageContext should support SQL or NoSQL persistence")
     }

--- a/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/SqlSymbolInterner.kt
+++ b/jacodb-core/src/main/kotlin/org/jacodb/impl/storage/SqlSymbolInterner.kt
@@ -20,12 +20,12 @@ import org.jacodb.api.jvm.JcDatabasePersistence
 import org.jacodb.api.storage.ConcurrentSymbolInterner
 import org.jacodb.api.storage.StorageContext
 import org.jacodb.impl.storage.jooq.tables.references.SYMBOLS
-import org.jooq.DSLContext
 
 class SqlSymbolInterner : ConcurrentSymbolInterner() {
 
     fun setup(persistence: JcDatabasePersistence) = persistence.read { context ->
-        context.execute { jooq ->
+        context.execute {
+            val jooq = context.dslContext
             jooq.selectFrom(SYMBOLS).fetch().forEach {
                 val (id, name) = it
                 if (name != null && id != null) {
@@ -56,7 +56,7 @@ class SqlSymbolInterner : ConcurrentSymbolInterner() {
         }
     }
 
-    private fun StorageContext.execute(action: (DSLContext) -> Unit) {
+    private fun StorageContext.execute(action: () -> Unit) {
         execute(sqlAction = action, noSqlAction = { error("Can't execute NoSql action in SqlSymbolInterner") })
     }
 }


### PR DESCRIPTION
[jacodb-benchmarks] Update IC classpath to ideaIC-2024.3.2.2.win.zip

[jacodb-core] Refactor StorageContext.execute() and it usages

In this commit, explicit referring to DSLContext in signature of StorageContext.execute() is eliminated.