### PR TITLE
Add GHA workflow to trigger JitPack builds

### DIFF
--- a/.github/workflows/trigger-jitpack-build.yml
+++ b/.github/workflows/trigger-jitpack-build.yml
@@ -1,0 +1,13 @@
+name: Trigger Jitpack Build
+on:
+  push:
+    branches: [ develop, neo ]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Jitpack Build
+        run: |
+          JITPACK_URL="https://jitpack.io/com/github/${{ github.repository }}/${GITHUB_SHA:0:10}/build.log"
+          curl -s -m 300 ${JITPACK_URL}


### PR DESCRIPTION
This PR adds GitHub Actions workflow that trigger JitPack build (using simple curl request for `build.log`) after pushes to `develop` and `neo` (e.g., after merging PRs).