### PR TITLE
[jacodb-core] In JarFacade, avoid caching JarEntries returned by JarFile

### DIFF
--- a/jacodb-core/src/test/kotlin/org/jacodb/testing/persistence/incrementality/IncrementalDbTest.kt
+++ b/jacodb-core/src/test/kotlin/org/jacodb/testing/persistence/incrementality/IncrementalDbTest.kt
@@ -19,15 +19,12 @@ package org.jacodb.testing.persistence.incrementality
 import kotlinx.coroutines.runBlocking
 import org.jacodb.api.jvm.ext.findClass
 import org.jacodb.testing.WithDb
+import org.jacodb.testing.cookJar
+import org.jacodb.testing.createTempJar
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import java.net.URL
 import java.nio.file.Files
-import java.nio.file.Files.createDirectories
-import java.nio.file.Path
 import java.nio.file.StandardCopyOption
-import kotlin.io.path.Path
-import kotlin.io.path.createTempDirectory
 
 class IncrementalDbTest {
 
@@ -55,16 +52,4 @@ class IncrementalDbTest {
         db.awaitBackgroundJobs()
         Assertions.assertTrue(bc1 contentEquals cp.findClass("com.github.penemue.keap.PriorityQueue").bytecode())
     }
-
-    private fun cookJar(link: String): Path {
-        val url = URL(link)
-        val result = createTempJar(url.file)
-        Files.copy(url.openStream(), result, StandardCopyOption.REPLACE_EXISTING)
-        return result
-    }
-
-    private fun createTempJar(name: String) =
-        Path(createTempDirectory("jcdb-temp-jar").toString(), name).also {
-            createDirectories(it.parent)
-        }
 }

--- a/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/Jars.kt
+++ b/jacodb-core/src/testFixtures/kotlin/org/jacodb/testing/Jars.kt
@@ -14,20 +14,24 @@
  *  limitations under the License.
  */
 
-package org.jacodb.impl.util
+package org.jacodb.testing
 
-import java.util.*
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Files.createDirectories
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.Path
+import kotlin.io.path.createTempDirectory
 
-inline fun <T> Sequence(crossinline it: () -> Iterable<T>): Sequence<T> = object : Sequence<T> {
-    override fun iterator(): Iterator<T> = it().iterator()
+fun cookJar(link: String): Path {
+    val url = URL(link)
+    val result = createTempJar(url.file)
+    Files.copy(url.openStream(), result, StandardCopyOption.REPLACE_EXISTING)
+    return result
 }
 
-fun <T> Enumeration<T>?.asSequence(): Sequence<T> {
-    if (this == null) return emptySequence()
-    return object : Sequence<T> {
-        override fun iterator(): Iterator<T> = object : Iterator<T> {
-            override fun hasNext() = this@asSequence.hasMoreElements()
-            override fun next(): T = this@asSequence.nextElement()
-        }
+fun createTempJar(name: String) =
+    Path(createTempDirectory("jcdb-temp-jar").toString(), name).also {
+        createDirectories(it.parent)
     }
-}


### PR DESCRIPTION
Some implementations of JarEntry are inner classes referencing their JarFiles for doing some internal checks,e.g., on getting input stream. Such caching may require the JarFiles to always be open. To address the issue, copies of all JarEntries should be cached.