### PR TITLE
Set scene for all files

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Scene.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Scene.kt
@@ -22,6 +22,11 @@ class EtsScene(
     val projectFiles: List<EtsFile>,
     val sdkFiles: List<EtsFile> = emptyList(),
 ) : CommonProject {
+    init {
+        projectFiles.forEach { it.scene = this }
+        sdkFiles.forEach { it.scene = this }
+    }
+
     val projectClasses: List<EtsClass>
         get() = projectFiles.flatMap { it.allClasses }
 


### PR DESCRIPTION
This PR fixes #320 by setting the `.scene` property to the enclosing `EtsScene` for all project and SDK files in scene.