### PR TITLE
[jacodb-ets] Change 'arg' in AwaitExpr to be Local

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
@@ -278,7 +278,7 @@ class EtsMethodBuilder(
         )
 
         is AwaitExprDto -> EtsAwaitExpr(
-            arg = arg.toEtsEntity(),
+            arg = ensureLocal(arg.toEtsEntity()),
             type = type.toEtsType(),
         )
 

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Expr.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Expr.kt
@@ -218,7 +218,7 @@ data class EtsDeleteExpr(
 }
 
 data class EtsAwaitExpr(
-    override val arg: EtsEntity,
+    override val arg: EtsLocal,
     override val type: EtsType,
 ) : EtsUnaryExpr {
     override fun toString(): String {


### PR DESCRIPTION
This PR changes `arg` in `EtsAwaitExpr` to be `EtsLocal` instead of an arbitrary value.