### PR TITLE
Support EtsLexicalEnvType

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           DEST_DIR="arkanalyzer"
           MAX_RETRIES=10
           RETRY_DELAY=3  # Delay between retries in seconds
-          BRANCH="neo/2025-06-16"
+          BRANCH="neo/2025-07-16"
 
           for ((i=1; i<=MAX_RETRIES; i++)); do
               git clone --depth=1 --branch $BRANCH $REPO_URL $DEST_DIR && break

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           DEST_DIR="arkanalyzer"
           MAX_RETRIES=10
           RETRY_DELAY=3  # Delay between retries in seconds
-          BRANCH="neo/2025-07-16"
+          BRANCH="neo/2025-07-18"
 
           for ((i=1; i<=MAX_RETRIES; i++)); do
               git clone --depth=1 --branch $BRANCH $REPO_URL $DEST_DIR && break

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
@@ -35,11 +35,13 @@ import org.jacodb.ets.model.EtsBooleanType
 import org.jacodb.ets.model.EtsCallExpr
 import org.jacodb.ets.model.EtsCallStmt
 import org.jacodb.ets.model.EtsCastExpr
+import org.jacodb.ets.model.EtsCaughtExceptionRef
 import org.jacodb.ets.model.EtsClass
 import org.jacodb.ets.model.EtsClassCategory
 import org.jacodb.ets.model.EtsClassImpl
 import org.jacodb.ets.model.EtsClassSignature
 import org.jacodb.ets.model.EtsClassType
+import org.jacodb.ets.model.EtsClosureFieldRef
 import org.jacodb.ets.model.EtsConstant
 import org.jacodb.ets.model.EtsDecorator
 import org.jacodb.ets.model.EtsDeleteExpr
@@ -57,6 +59,7 @@ import org.jacodb.ets.model.EtsFile
 import org.jacodb.ets.model.EtsFileSignature
 import org.jacodb.ets.model.EtsFunctionType
 import org.jacodb.ets.model.EtsGenericType
+import org.jacodb.ets.model.EtsGlobalRef
 import org.jacodb.ets.model.EtsGtEqExpr
 import org.jacodb.ets.model.EtsGtExpr
 import org.jacodb.ets.model.EtsIfStmt
@@ -394,6 +397,21 @@ class EtsMethodBuilder(
         )
 
         is FieldRefDto -> toEtsFieldRef()
+
+        is CaughtExceptionRefDto -> EtsCaughtExceptionRef(
+            type = type.toEtsType(),
+        )
+
+        is GlobalRefDto -> EtsGlobalRef(
+            name = name,
+            ref = ref?.let { ensureLocal(it.toEtsEntity()) },
+        )
+
+        is ClosureFieldRefDto -> EtsClosureFieldRef(
+            base = base.toEtsLocal(),
+            fieldName = fieldName,
+            type = type.toEtsType(),
+        )
 
         is RawValueDto -> EtsRawEntity(
             kind = kind,

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
@@ -66,6 +66,7 @@ import org.jacodb.ets.model.EtsInstanceFieldRef
 import org.jacodb.ets.model.EtsInstanceOfExpr
 import org.jacodb.ets.model.EtsIntersectionType
 import org.jacodb.ets.model.EtsLeftShiftExpr
+import org.jacodb.ets.model.EtsLexicalEnvType
 import org.jacodb.ets.model.EtsLiteralType
 import org.jacodb.ets.model.EtsLocal
 import org.jacodb.ets.model.EtsLocalSignature
@@ -511,6 +512,11 @@ fun TypeDto.toEtsType(): EtsType = when (this) {
 
     is IntersectionTypeDto -> EtsIntersectionType(
         types = types.map { it.toEtsType() },
+    )
+
+    is LexicalEnvTypeDto -> EtsLexicalEnvType(
+        nestedMethod = method.toEtsMethodSignature(),
+        closures = closures.map { it.toEtsLocal() },
     )
 
     is LiteralTypeDto -> EtsLiteralType(

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Types.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Types.kt
@@ -62,6 +62,13 @@ data class AliasTypeDto(
 ) : TypeDto
 
 @Serializable
+@SerialName("LexicalEnvType")
+data class LexicalEnvTypeDto(
+    val method: MethodSignatureDto,
+    val closures: List<LocalDto>,
+) : TypeDto
+
+@Serializable
 @SerialName("EnumValueType")
 data class EnumValueTypeDto(
     val signature: FieldSignatureDto,

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Values.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Values.kt
@@ -287,29 +287,29 @@ data class ParameterRefDto(
     override val type: TypeDto,
 ) : RefDto
 
-// @Serializable
-// @SerialName("CaughtExceptionRef")
-// data class CaughtExceptionRefDto(
-//     override val type: TypeDto,
-// ) : RefDto
-//
-// @Serializable
-// @SerialName("GlobalRef")
-// data class GlobalRefDto(
-//     val name: String,
-//     val ref: ValueDto?,
-// ) : RefDto {
-//     override val type: TypeDto
-//         get() = ref?.type ?: UnknownTypeDto
-// }
-//
-// @Serializable
-// @SerialName("ClosureFieldRef")
-// data class ClosureFieldRefDto(
-//     val base: LocalDto,
-//     val fieldName: String,
-//     override val type: TypeDto,
-// ) : RefDto
+@Serializable
+@SerialName("CaughtExceptionRef")
+data class CaughtExceptionRefDto(
+    override val type: TypeDto,
+) : RefDto
+
+@Serializable
+@SerialName("GlobalRef")
+data class GlobalRefDto(
+    val name: String,
+    val ref: ValueDto?,
+) : RefDto {
+    override val type: TypeDto
+        get() = ref?.type ?: UnknownTypeDto
+}
+
+@Serializable
+@SerialName("ClosureFieldRef")
+data class ClosureFieldRefDto(
+    val base: LocalDto,
+    val fieldName: String,
+    override val type: TypeDto,
+) : RefDto
 
 @Serializable
 @SerialName("ArrayRef")

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Expr.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Expr.kt
@@ -736,7 +736,7 @@ data class EtsInstanceCallExpr(
     override val type: EtsType,
 ) : EtsCallExpr, CommonInstanceCallExpr {
     override fun toString(): String {
-        return "$instance.${callee.name}(${args.joinToString()})"
+        return "virtual ${instance}.${callee.name}(${args.joinToString()})"
     }
 
     override fun <R> accept(visitor: EtsExpr.Visitor<R>): R {
@@ -750,7 +750,7 @@ data class EtsStaticCallExpr(
     override val type: EtsType,
 ) : EtsCallExpr {
     override fun toString(): String {
-        return "${callee.enclosingClass.name}.${callee.name}(${args.joinToString()})"
+        return "static ${callee.enclosingClass.name}.${callee.name}(${args.joinToString()})"
     }
 
     override fun <R> accept(visitor: EtsExpr.Visitor<R>): R {
@@ -765,7 +765,7 @@ data class EtsPtrCallExpr(
     override val type: EtsType,
 ) : EtsCallExpr {
     override fun toString(): String {
-        return "${ptr}<${callee.name}>(${args.joinToString()})"
+        return "ptr ${ptr}(${args.joinToString()})"
     }
 
     override fun <R> accept(visitor: EtsExpr.Visitor<R>): R {

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Expr.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Expr.kt
@@ -765,7 +765,7 @@ data class EtsPtrCallExpr(
     override val type: EtsType,
 ) : EtsCallExpr {
     override fun toString(): String {
-        return "${ptr}.${callee.name}(${args.joinToString()})"
+        return "${ptr}<${callee.name}>(${args.joinToString()})"
     }
 
     override fun <R> accept(visitor: EtsExpr.Visitor<R>): R {

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Local.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Local.kt
@@ -21,6 +21,9 @@ data class EtsLocal(
     override val type: EtsType = EtsUnknownType,
 ) : EtsImmediate, EtsLValue {
     override fun toString(): String {
+        if (type is EtsLexicalEnvType) {
+            return "$name<${type.closures.joinToString(",")}>"
+        }
         return name
     }
 

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Ref.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Ref.kt
@@ -94,3 +94,45 @@ data class EtsStaticFieldRef(
         return visitor.visit(this)
     }
 }
+
+data class EtsCaughtExceptionRef(
+    override val type: EtsType,
+) : EtsRef {
+    override fun toString(): String {
+        return "caught $type"
+    }
+
+    override fun <R> accept(visitor: EtsValue.Visitor<R>): R {
+        return visitor.visit(this)
+    }
+}
+
+data class EtsGlobalRef(
+    val name: String,
+    val ref: EtsLocal?,
+) : EtsRef {
+    override val type: EtsType
+        get() = ref?.type ?: EtsUnknownType
+
+    override fun toString(): String {
+        return "global $name"
+    }
+
+    override fun <R> accept(visitor: EtsValue.Visitor<R>): R {
+        return visitor.visit(this)
+    }
+}
+
+data class EtsClosureFieldRef(
+    val base: EtsLocal,
+    val fieldName: String,
+    override val type: EtsType,
+) : EtsRef {
+    override fun toString(): String {
+        return "$base.$fieldName"
+    }
+
+    override fun <R> accept(visitor: EtsValue.Visitor<R>): R {
+        return visitor.visit(this)
+    }
+}

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Type.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Type.kt
@@ -377,9 +377,11 @@ data class EtsFunctionType(
 }
 
 data class EtsLexicalEnvType(
+    @Deprecated("This signature is incomplete due to the removed cyclic reference. You probably do not want to rely on it.")
     val nestedMethod: EtsMethodSignature,
     val closures: List<EtsLocal>,
 ) : EtsType {
+    @Suppress("DEPRECATION")
     override val typeName: String
         get() = "${nestedMethod.name}(${closures.joinToString { it.name }})"
 

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Type.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Type.kt
@@ -30,6 +30,7 @@ interface EtsType : TypeName, CommonType {
         fun visit(type: EtsIntersectionType): R
         fun visit(type: EtsGenericType): R
         fun visit(type: EtsAliasType): R
+        fun visit(type: EtsLexicalEnvType): R
         fun visit(type: EtsEnumValueType): R
 
         // Primitive
@@ -63,6 +64,7 @@ interface EtsType : TypeName, CommonType {
             override fun visit(type: EtsIntersectionType): R = defaultVisit(type)
             override fun visit(type: EtsGenericType): R = defaultVisit(type)
             override fun visit(type: EtsAliasType): R = defaultVisit(type)
+            override fun visit(type: EtsLexicalEnvType): R = defaultVisit(type)
             override fun visit(type: EtsEnumValueType): R = defaultVisit(type)
 
             override fun visit(type: EtsBooleanType): R = defaultVisit(type)
@@ -374,10 +376,24 @@ data class EtsFunctionType(
     }
 }
 
+data class EtsLexicalEnvType(
+    val nestedMethod: EtsMethodSignature,
+    val closures: List<EtsLocal>,
+) : EtsType {
+    override val typeName: String
+        get() = "${nestedMethod.name}(${closures.joinToString { it.name }})"
+
+    override fun toString(): String = typeName
+
+    override fun <R> accept(visitor: EtsType.Visitor<R>): R {
+        return visitor.visit(this)
+    }
+}
+
 data class EtsEnumValueType(
     val signature: EtsFieldSignature,
     val constant: EtsConstant? = null,
-): EtsType {
+) : EtsType {
     override val typeName: String
         get() = signature.name
 

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Value.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Value.kt
@@ -37,6 +37,10 @@ interface EtsValue : EtsEntity, CommonValue {
         fun visit(value: EtsInstanceFieldRef): R
         fun visit(value: EtsStaticFieldRef): R
 
+        fun visit(value: EtsCaughtExceptionRef): R
+        fun visit(value: EtsGlobalRef): R
+        fun visit(value: EtsClosureFieldRef): R
+
         interface Default<out R> : Visitor<R> {
             override fun visit(value: EtsLocal): R = defaultVisit(value)
 
@@ -52,6 +56,10 @@ interface EtsValue : EtsEntity, CommonValue {
             override fun visit(value: EtsArrayAccess): R = defaultVisit(value)
             override fun visit(value: EtsInstanceFieldRef): R = defaultVisit(value)
             override fun visit(value: EtsStaticFieldRef): R = defaultVisit(value)
+
+            override fun visit(value: EtsCaughtExceptionRef): R = defaultVisit(value)
+            override fun visit(value: EtsGlobalRef): R = defaultVisit(value)
+            override fun visit(value: EtsClosureFieldRef): R = defaultVisit(value)
 
             fun defaultVisit(value: EtsValue): R
         }

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/GetOperands.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/GetOperands.kt
@@ -28,12 +28,15 @@ import org.jacodb.ets.model.EtsBitXorExpr
 import org.jacodb.ets.model.EtsBooleanConstant
 import org.jacodb.ets.model.EtsCallStmt
 import org.jacodb.ets.model.EtsCastExpr
+import org.jacodb.ets.model.EtsCaughtExceptionRef
+import org.jacodb.ets.model.EtsClosureFieldRef
 import org.jacodb.ets.model.EtsConstant
 import org.jacodb.ets.model.EtsDeleteExpr
 import org.jacodb.ets.model.EtsDivExpr
 import org.jacodb.ets.model.EtsEntity
 import org.jacodb.ets.model.EtsEqExpr
 import org.jacodb.ets.model.EtsExpExpr
+import org.jacodb.ets.model.EtsGlobalRef
 import org.jacodb.ets.model.EtsGtEqExpr
 import org.jacodb.ets.model.EtsGtExpr
 import org.jacodb.ets.model.EtsIfStmt
@@ -152,6 +155,15 @@ private object EntityGetOperands : EtsEntity.Visitor<Sequence<EtsEntity>> {
 
     override fun visit(value: EtsStaticFieldRef): Sequence<EtsEntity> =
         emptySequence()
+
+    override fun visit(value: EtsCaughtExceptionRef): Sequence<EtsEntity> =
+        emptySequence()
+
+    override fun visit(value: EtsGlobalRef): Sequence<EtsEntity> =
+        listOfNotNull(value.ref).asSequence()
+
+    override fun visit(value: EtsClosureFieldRef): Sequence<EtsEntity> =
+        sequenceOf(value.base)
 
     override fun visit(expr: EtsNewExpr): Sequence<EtsEntity> =
         emptySequence()

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/Handler.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/utils/Handler.kt
@@ -28,12 +28,15 @@ import org.jacodb.ets.model.EtsBitXorExpr
 import org.jacodb.ets.model.EtsBooleanConstant
 import org.jacodb.ets.model.EtsCallStmt
 import org.jacodb.ets.model.EtsCastExpr
+import org.jacodb.ets.model.EtsCaughtExceptionRef
+import org.jacodb.ets.model.EtsClosureFieldRef
 import org.jacodb.ets.model.EtsConstant
 import org.jacodb.ets.model.EtsDeleteExpr
 import org.jacodb.ets.model.EtsDivExpr
 import org.jacodb.ets.model.EtsEntity
 import org.jacodb.ets.model.EtsEqExpr
 import org.jacodb.ets.model.EtsExpExpr
+import org.jacodb.ets.model.EtsGlobalRef
 import org.jacodb.ets.model.EtsGtEqExpr
 import org.jacodb.ets.model.EtsGtExpr
 import org.jacodb.ets.model.EtsIfStmt
@@ -82,6 +85,27 @@ import org.jacodb.ets.model.EtsUndefinedConstant
 import org.jacodb.ets.model.EtsUnsignedRightShiftExpr
 import org.jacodb.ets.model.EtsVoidExpr
 import org.jacodb.ets.model.EtsYieldExpr
+
+/**
+ * An example handler for [EtsEntity] and [EtsStmt].
+ *
+ * This class is not meant to be used directly, but rather serves as a template for creating custom handlers.
+ *
+ * **Note:** this class might seem as completely useless, but it actually guards
+ * from missing any of the visit methods in the future.
+ * If this fails to compile, you might need to implement new methods in [AbstractHandler].
+ */
+class ExampleHandler : AbstractHandler() {
+    override fun handle(value: EtsEntity) {
+        // Handle the entity
+        println("entity: $value")
+    }
+
+    override fun handle(stmt: EtsStmt) {
+        // Handle the statement
+        println("statement: $stmt")
+    }
+}
 
 abstract class AbstractHandler : EtsEntity.Visitor<Unit>, EtsStmt.Visitor<Unit> {
 
@@ -175,6 +199,20 @@ abstract class AbstractHandler : EtsEntity.Visitor<Unit>, EtsStmt.Visitor<Unit> 
 
     final override fun visit(value: EtsStaticFieldRef) {
         handle(value)
+    }
+
+    final override fun visit(value: EtsCaughtExceptionRef) {
+        handle(value)
+    }
+
+    final override fun visit(value: EtsGlobalRef) {
+        handle(value)
+        value.ref?.accept(this)
+    }
+
+    final override fun visit(value: EtsClosureFieldRef) {
+        handle(value)
+        value.base.accept(this)
     }
 
     final override fun visit(expr: EtsNewExpr) {


### PR DESCRIPTION
This PR adds support for `LexicalEnvType`. Specifically, it adds the DTO, extends the model, and provides the converter. In addition, this PR bumps ArkAnalyzer to branch `neo/2025-07-18`, which supports the serialization of `LexicalEnvType`.