### PR TITLE
Remove `oss.sonatype` maven repo

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,6 @@ allprojects {
     repositories {
         mavenCentral()
         maven("https://jitpack.io")
-        maven("https://s01.oss.sonatype.org/content/repositories/orgunittestbotsoot-1004/")
         maven("https://plugins.gradle.org/m2")
         maven("https://www.jetbrains.com/intellij-repository/releases")
         maven("https://cache-redirector.jetbrains.com/maven-central")


### PR DESCRIPTION
This PR removes the additional maven repository at `s01.oss.sonatype.org` for `org.unittestbot.soot` dependency.

This repo is not accessible ([504](https://s01.oss.sonatype.org/content/repositories/orgunittestbotsoot-1004/)) anymore and prevents building `jacodb` on JitPack, e.g. see https://jitpack.io/com/github/UnitTestBot/jacodb/16b0733924/build.log. This failure can be reproduced locally in a clean Gradle environment. The resolution error goes away if there is NO additional oss maven repository specified. Seems like this dependency was to moved to [Maven Central](https://repo1.maven.org/maven2/org/unittestbot/soot/soot-utbot-fork/), so the default `mavenRepository()` setup is enough.

Related read: https://central.sonatype.org/pages/ossrh-eol/

---

Successful JitPack build of this PR: https://jitpack.io/com/github/UnitTestBot/jacodb/96e8591354/build.log