### PR TITLE
Cleanup maven publication

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -204,8 +204,6 @@ configure(
                             dependency.version.isNullOrBlank()
                         }
                     }
-                artifact(sourcesJar)
-                artifact(dokkaJavadocJar)
                 addPom()
                 signPublication(this@configure)
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -220,10 +220,10 @@ configure(
             }
 
             // Use `./gradlew publishAllPublicationsToBuildRepository -Pversion=1.5`
-            // to publish to `./build/repository` directory.
+            // to publish to `/build/repository` directory in the root project.
             maven {
                 name = "Build"
-                url = uri(layout.buildDirectory.dir("repository"))
+                url = uri(rootProject.layout.buildDirectory.dir("repository"))
             }
         }
     }


### PR DESCRIPTION
This PR removes unnecessary artifacts from maven publication, since they already present in components. In particular, when `includeDokka` is `false`, the corresponding task that composes a javadoc jar should not be executed and included as an artifact of the publication. The existing code contained the conditional setup of `dokkaJavadocJar` artifact, but also erroneously included this artifact in the publication unconditionally. This PR should fix it.