### PR TITLE
Use java 8 to publish snapshots

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: 8
+          distribution: temurin
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
This PR updates CI workflow for publishing snapshots to use JDK 8.