### PR TITLE
Bump kx-serialization to 1.8.1 to avoid `RawValue` deserialization bug

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     const val kotlinx_collections_immutable = "0.3.5"
     const val kotlinx_coroutines = "1.6.4"
     const val kotlin_metadata = kotlin
-    const val kotlinx_serialization = "1.8.0"
+    const val kotlinx_serialization = "1.8.1"
     const val licenser = "0.6.1"
     const val mockk = "1.13.3"
     const val sarif4k = "0.5.0"

--- a/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsFromJsonTest.kt
+++ b/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsFromJsonTest.kt
@@ -20,7 +20,9 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonPrimitive
 import mu.KotlinLogging
 import org.jacodb.ets.dto.AnyTypeDto
+import org.jacodb.ets.dto.AssignStmtDto
 import org.jacodb.ets.dto.ClassSignatureDto
+import org.jacodb.ets.dto.ClosureFieldRefDto
 import org.jacodb.ets.dto.DecoratorDto
 import org.jacodb.ets.dto.FieldDto
 import org.jacodb.ets.dto.FieldSignatureDto
@@ -492,5 +494,50 @@ class EtsFromJsonTest {
         assertEquals(2, cls.fields.size)
         assertEquals("Cat", cls.fields[0].name)
         assertEquals("Dog", cls.fields[1].name)
+    }
+
+    @Test
+    fun testClosureFieldRefDto() {
+        val s = """
+            {
+              "_": "ClosureFieldRef",
+              "base": {
+                "name": "a",
+                "type": { "_": "UnknownType" }
+              },
+              "fieldName": "foo",
+              "type": { "_": "UnknownType" }
+            }
+        """.trimIndent()
+        val dto = json.decodeFromString<ValueDto>(s)
+        logger.info { "dto = $dto" }
+        assertIs<ClosureFieldRefDto>(dto)
+    }
+
+    @Test
+    fun testAssignArrayRefDto() {
+        val s = """
+            {
+              "_": "AssignStmt",
+              "left": {
+                "_": "Local",
+                "name": "x",
+                "type": { "_": "NumberType" }
+              },
+              "right": {
+                "_": "ClosureFieldRef",
+                "base": {
+                  "name": "a",
+                  "type": { "_": "UnknownType" }
+                },
+                "fieldName": "foo",
+                "type": { "_": "UnknownType" }
+              }
+            }
+        """.trimIndent()
+        val dto = json.decodeFromString<StmtDto>(s)
+        logger.info { "dto = $dto" }
+        assertIs<AssignStmtDto>(dto)
+        assertIs<ClosureFieldRefDto>(dto.right)
     }
 }


### PR DESCRIPTION
This PR bumps `kotlinx-serialization` to `1.8.1`. The included test repreduces the deserialization failure on `1.8.0`.