### PR TITLE
Add `modifiers` getter

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Modifiers.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Modifiers.kt
@@ -60,5 +60,8 @@ value class EtsModifiers(val mask: Int) : WithModifiers {
         val EMPTY = EtsModifiers(0)
     }
 
+    val modifiers: List<EtsModifier>
+        get() = EtsModifier.entries.filter { hasModifier(it) }
+
     override fun hasModifier(modifier: EtsModifier): Boolean = (mask and modifier.value) != 0
 }


### PR DESCRIPTION
This PR adds `EtsModifiers::modifiers: List<EtsModifier>` getter which is useful for debugging.