### PR TITLE
Add method body with cfg and locals

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
@@ -143,15 +143,22 @@ class EtsMethodBuilder(
     typeParameters: List<EtsType> = emptyList(),
     modifiers: EtsModifiers = EtsModifiers.EMPTY,
     decorators: List<EtsDecorator> = emptyList(),
+    locals: List<EtsLocal> = emptyList(),
 ) {
-    private val method = EtsMethodImpl(signature, typeParameters, modifiers, decorators)
+    private val locals = locals.toMutableList()
+
+    private val method = EtsMethodImpl(signature, typeParameters, modifiers, decorators).also {
+        it.body.locals = this.locals
+    }
 
     private lateinit var currentStmts: MutableList<EtsStmt>
 
     private var freeTempLocal: Int = 0
 
     private fun newTempLocal(): EtsLocal {
-        return EtsLocal("_tmp${freeTempLocal++}")
+        val local = EtsLocal("_tmp${freeTempLocal++}")
+        this@EtsMethodBuilder.locals += local
+        return local
     }
 
     private fun loc(): EtsStmtLocation {
@@ -163,7 +170,7 @@ class EtsMethodBuilder(
     fun build(cfgDto: CfgDto): EtsMethod {
         require(!built) { "Method has already been built" }
         val cfg = cfgDto.toEtsCfg()
-        method._cfg = cfg
+        method.body.cfg = cfg
         built = true
         return method
     }
@@ -682,6 +689,7 @@ fun MethodDto.toEtsMethod(): EtsMethod {
             typeParameters = typeParameters,
             modifiers = modifiers,
             decorators = decorators,
+            locals = body.locals.map { it.toEtsLocal() },
         )
         return builder.build(body.cfg)
     } else {

--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Method.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Method.kt
@@ -23,7 +23,7 @@ import org.jacodb.api.common.CommonMethod
 interface EtsMethod : Base, CommonMethod {
     val signature: EtsMethodSignature
     val typeParameters: List<EtsType>
-    val cfg: EtsBlockCfg
+    val body: EtsMethodBody
 
     val enclosingClass: EtsClass?
 
@@ -36,10 +36,21 @@ interface EtsMethod : Base, CommonMethod {
     override val returnType: EtsType
         get() = signature.returnType
 
+    val cfg: EtsBlockCfg
+        get() = body.cfg
+
+    val locals: List<EtsLocal>
+        get() = body.locals
+
     override fun flowGraph(): EtsBytecodeGraph<EtsStmt> {
         return cfg
     }
 }
+
+class EtsMethodBody(
+    var cfg: EtsBlockCfg = EtsBlockCfg.EMPTY,
+    var locals: List<EtsLocal> = emptyList(),
+)
 
 class EtsMethodImpl(
     override val signature: EtsMethodSignature,
@@ -47,10 +58,14 @@ class EtsMethodImpl(
     override val modifiers: EtsModifiers = EtsModifiers.EMPTY,
     override val decorators: List<EtsDecorator> = emptyList(),
 ) : EtsMethod {
-    var _cfg: EtsBlockCfg? = null
+    override val body: EtsMethodBody = EtsMethodBody()
 
-    override val cfg: EtsBlockCfg
-        get() = _cfg ?: EtsBlockCfg.EMPTY
+    @Deprecated("Use body.cfg instead", ReplaceWith("body.cfg"))
+    var _cfg: EtsBlockCfg
+        get() = body.cfg
+        set(value) {
+            body.cfg = value
+        }
 
     override var enclosingClass: EtsClass? = null
 

--- a/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsCfgDslTest.kt
+++ b/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsCfgDslTest.kt
@@ -24,8 +24,10 @@ import org.jacodb.ets.dsl.param
 import org.jacodb.ets.dsl.program
 import org.jacodb.ets.dsl.toBlockCfg
 import org.jacodb.ets.dsl.toDot
+import org.jacodb.ets.model.EtsAssignStmt
 import org.jacodb.ets.model.EtsClassSignature
 import org.jacodb.ets.model.EtsFileSignature
+import org.jacodb.ets.model.EtsLocal
 import org.jacodb.ets.model.EtsMethodImpl
 import org.jacodb.ets.model.EtsMethodParameter
 import org.jacodb.ets.model.EtsMethodSignature
@@ -35,6 +37,8 @@ import org.jacodb.ets.utils.linearize
 import org.jacodb.ets.utils.toDot
 import org.jacodb.ets.utils.toEtsBlockCfg
 import org.junit.jupiter.api.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 
 class EtsCfgDslTest {
     @Test
@@ -80,5 +84,14 @@ class EtsCfgDslTest {
         println("etsCfg:\n${etsCfg.toDot()}")
 
         method.body.cfg = etsBlockCfg
+        method.body.locals = etsBlockCfg.stmts
+            .filterIsInstance<EtsAssignStmt>()
+            .mapNotNull { it.lhv as? EtsLocal }
+            .distinct()
+
+        assertEquals(method.locals, listOf(
+            EtsLocal("i", EtsUnknownType),
+            EtsLocal("_tmp0", EtsUnknownType),
+        ))
     }
 }

--- a/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsCfgDslTest.kt
+++ b/jacodb-ets/src/test/kotlin/org/jacodb/ets/test/EtsCfgDslTest.kt
@@ -79,6 +79,6 @@ class EtsCfgDslTest {
         val etsCfg = etsBlockCfg.linearize()
         println("etsCfg:\n${etsCfg.toDot()}")
 
-        method._cfg = etsBlockCfg
+        method.body.cfg = etsBlockCfg
     }
 }


### PR DESCRIPTION
This PR adds `val body: EtsMethodBody` with CFG and locals (taken from IR).

Note that all "locals" (that could be found in IR) that do not present in this list of locals, are actually not locals, but probably global variables or other out of scope refs. For example `x := 42` when `method.body.locals` list *does not* contain `x`, actually means "modify the global variable `x`", _not local_.