### PR TITLE
Add modifiersList property

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Modifiers.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/model/Modifiers.kt
@@ -52,7 +52,7 @@ interface WithModifiers {
     val isDeclare: Boolean get() = hasModifier(EtsModifier.DECLARE)
 
     fun hasModifier(modifier: EtsModifier): Boolean
-    
+
     val modifiersList: List<EtsModifier>
         get() = EtsModifier.entries.filter { hasModifier(it) }
 }


### PR DESCRIPTION
This PR replaces `EtsModifiers::modifiers` with `WithModifiers::modifiersList` getter for debugging purposes.