### PR TITLE
Replace casts with checks, ignore CastExpr in LHS of AssignStmt

### DIFF
--- a/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
+++ b/jacodb-ets/src/main/kotlin/org/jacodb/ets/dto/Convert.kt
@@ -194,8 +194,11 @@ class EtsMethodBuilder(
         if (entity is EtsExpr || entity is EtsFieldRef || entity is EtsArrayAccess) {
             return ensureLocal(entity)
         } else {
-            check(entity is EtsValue) {
-                "Expected EtsValue, but got $entity"
+            if (entity !is EtsValue) {
+                logger.error {
+                    "Expected EtsValue, but got ${entity::class.java}: $entity\nMethod: $method"
+                }
+                error("Expected EtsValue, but got ${entity::class.java}")
             }
             return entity
         }
@@ -207,9 +210,19 @@ class EtsMethodBuilder(
         }
 
         is AssignStmtDto -> {
-            val lhv = left.toEtsEntity() as EtsValue // safe cast
-            check(lhv is EtsLocal || lhv is EtsFieldRef || lhv is EtsArrayAccess) {
-                "LHV of AssignStmt should be EtsLocal, EtsFieldRef, or EtsArrayAccess, but got $lhv"
+            val lhv = left.toEtsEntity().let {
+                // Drop cast on LHV
+                if (it is EtsCastExpr) {
+                    it.arg
+                } else {
+                    it
+                }
+            }
+            if (!(lhv is EtsLocal || lhv is EtsFieldRef || lhv is EtsArrayAccess)) {
+                logger.error {
+                    "LHV of AssignStmt should be EtsLocal, EtsFieldRef, or EtsArrayAccess, but got ${lhv::class.java}: $lhv\nMethod: $method\nStmt: $this"
+                }
+                error("LHV of AssignStmt should be EtsLocal, EtsFieldRef, or EtsArrayAccess, but got ${lhv::class.java}")
             }
             val rhv = right.toEtsEntity().let { rhv ->
                 if (lhv is EtsLocal) {
@@ -232,7 +245,13 @@ class EtsMethodBuilder(
         }
 
         is CallStmtDto -> {
-            val expr = expr.toEtsEntity() as EtsCallExpr // safe cast
+            val expr = expr.toEtsEntity()
+            if (expr !is EtsCallExpr) {
+                logger.error {
+                    "Expr in CallStmt should be EtsCallExpr, but got ${expr::class.java}: $expr\nMethod: $method\nStmt: $this"
+                }
+                error("Expr in CallStmt should be EtsCallExpr, but got ${expr::class.java}")
+            }
             EtsCallStmt(
                 location = loc(),
                 expr = expr,


### PR DESCRIPTION
This PR fixes the situation when the cast (`as ...`) fails and the JVM exception does not contain enough information to trace the error without a debugger.

Also, we ignore `CastExpr` in LHS of `AssignStmt`: this is a real construction in TypeScript, but since it does almost nothing, we decided to just ignore it, in order to avoid re-designing the model, which relied on the fact that LHS of assignment can only be local/ref/array.