### PR TITLE
Fix ci-ets: pin @types/node@18 for the ArkAnalyzer build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,11 +134,15 @@ jobs:
           echo "ARKANALYZER_DIR=$(realpath $DEST_DIR)" >> $GITHUB_ENV
           cd $DEST_DIR
 
+          # ArkAnalyzer's bundled TypeScript (ohos-typescript 4.9.5) cannot parse
+          # the d.ts files of the latest floating @types/node (e.g. ffi.d.ts uses
+          # newer syntax and breaks `npm run build` with TS1139 etc.), so pin a
+          # compatible major IN THE MANIFEST before the single `npm install`.
+          # NB: do not run a second `npm install <pkg>` afterwards — it re-resolves
+          # the tree and prunes ohos-typescript, which the postinstall script adds
+          # with --no-save (i.e. it is absent from package.json).
+          npm pkg set 'devDependencies.@types/node=18'
           npm install
-          # ArkAnalyzer's bundled TypeScript cannot parse the d.ts files of the
-          # latest floating @types/node (e.g. ffi.d.ts uses newer syntax and
-          # breaks `npm run build` with TS1139 etc.); pin a compatible major.
-          npm install --no-save @types/node@18
           npm run build
 
       - name: Run ETS tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,10 @@ jobs:
           cd $DEST_DIR
 
           npm install
+          # ArkAnalyzer's bundled TypeScript cannot parse the d.ts files of the
+          # latest floating @types/node (e.g. ffi.d.ts uses newer syntax and
+          # breaks `npm run build` with TS1139 etc.); pin a compatible major.
+          npm install --no-save @types/node@18
           npm run build
 
       - name: Run ETS tests


### PR DESCRIPTION
ArkAnalyzer's npm install pulls the floating latest @types/node, whose new d.ts files (e.g. ffi.d.ts) use syntax that ArkAnalyzer's bundled TypeScript cannot parse, so `npm run build` fails with TS1139/TS1005 errors and the whole ci-ets job dies before any Gradle test runs. Pin a compatible @types/node major right after npm install.